### PR TITLE
Add immersive Persian loading experience

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,195 @@
-.App {
-  text-align: center;
+:root {
+  color-scheme: dark;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+* {
+  box-sizing: border-box;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
+body {
+  margin: 0;
+  background-color: #020617;
+  font-family: 'Vazirmatn', 'IRANYekan', 'Tahoma', 'Segoe UI', sans-serif;
+  overflow: hidden;
 }
 
-.App-header {
-  background-color: #282c34;
+.app-shell {
+  position: relative;
   min-height: 100vh;
+  width: 100%;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  text-align: center;
+  padding: 0 2rem;
+  background: radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.15), transparent 60%),
+    radial-gradient(circle at 80% 80%, rgba(12, 74, 110, 0.2), transparent 55%), #020617;
+  color: #f8fafc;
+  overflow: hidden;
 }
 
-.App-link {
-  color: #61dafb;
+.gradient-layer {
+  position: absolute;
+  inset: -15%;
+  z-index: 0;
+  --p1x: 18%;
+  --p1y: 28%;
+  --p2x: 76%;
+  --p2y: 68%;
+  --p3x: 45%;
+  --p3y: 18%;
+  background:
+    radial-gradient(35% 40% at var(--p1x) var(--p1y), rgba(37, 99, 235, 0.55), transparent 70%),
+    radial-gradient(32% 38% at var(--p2x) var(--p2y), rgba(59, 130, 246, 0.35), transparent 75%),
+    radial-gradient(40% 45% at var(--p3x) var(--p3y), rgba(6, 182, 212, 0.35), transparent 75%),
+    radial-gradient(25% 30% at calc(100% - var(--p1x)) calc(100% - var(--p2y)), rgba(30, 64, 175, 0.4), transparent 65%);
+  filter: blur(0px) saturate(120%);
+  opacity: 0.9;
+  transform: translate3d(0, 0, 0) scale(1.05);
+  animation: meshFlow 24s ease-in-out infinite alternate;
 }
 
-@keyframes App-logo-spin {
-  from {
+.gradient-layer::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 50%, rgba(148, 163, 184, 0.15), transparent 65%);
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+@keyframes meshFlow {
+  0% {
+    --p1x: 14%;
+    --p1y: 24%;
+    --p2x: 78%;
+    --p2y: 70%;
+    --p3x: 48%;
+    --p3y: 22%;
+    transform: translate3d(-1%, 1%, 0) scale(1.05);
+  }
+  35% {
+    --p1x: 26%;
+    --p1y: 38%;
+    --p2x: 72%;
+    --p2y: 56%;
+    --p3x: 42%;
+    --p3y: 30%;
+    transform: translate3d(2%, -1%, 0) scale(1.08);
+  }
+  70% {
+    --p1x: 20%;
+    --p1y: 45%;
+    --p2x: 68%;
+    --p2y: 78%;
+    --p3x: 58%;
+    --p3y: 32%;
+    transform: translate3d(-2%, 2%, 0) scale(1.03);
+  }
+  100% {
+    --p1x: 32%;
+    --p1y: 34%;
+    --p2x: 82%;
+    --p2y: 62%;
+    --p3x: 46%;
+    --p3y: 18%;
+    transform: translate3d(2%, -2%, 0) scale(1.06);
+  }
+}
+
+.loading-card {
+  position: relative;
+  z-index: 1;
+  width: min(32rem, 90vw);
+  padding: 3.5rem 3rem 3rem;
+  border-radius: 1.75rem;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.86), rgba(2, 6, 23, 0.9));
+  box-shadow:
+    0 35px 60px rgba(2, 8, 23, 0.6),
+    inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+  backdrop-filter: blur(22px);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: inherit;
+  direction: rtl;
+}
+
+.loading-spinner {
+  position: relative;
+  margin: 0 auto 2.5rem;
+  width: min(10rem, 38vw);
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  background: conic-gradient(from 120deg, rgba(30, 64, 175, 0.1), rgba(59, 130, 246, 0.8), rgba(8, 47, 73, 0.4), rgba(30, 64, 175, 0.1));
+  animation: spin 6s linear infinite;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.65);
+}
+
+.spinner-core {
+  width: 60%;
+  height: 60%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, rgba(148, 163, 184, 0.35), transparent 65%),
+    rgba(2, 6, 23, 0.85);
+  box-shadow:
+    inset 0 0 25px rgba(30, 64, 175, 0.5),
+    0 0 30px rgba(59, 130, 246, 0.35);
+}
+
+@keyframes spin {
+  0% {
     transform: rotate(0deg);
   }
-  to {
+  100% {
     transform: rotate(360deg);
+  }
+}
+
+.loading-title {
+  margin: 0;
+  font-size: clamp(2.3rem, 4vw, 3.4rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.loading-subtitle {
+  margin: 1rem 0 2.5rem;
+  font-size: clamp(1.1rem, 2.3vw, 1.5rem);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.progress-track {
+  position: relative;
+  height: 0.55rem;
+  width: 100%;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.6);
+}
+
+.progress-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(14, 165, 233, 0.9), rgba(59, 130, 246, 1));
+  transition: width 1s linear;
+}
+
+.time-remaining {
+  margin-top: 1.75rem;
+  font-size: clamp(1.2rem, 3vw, 1.8rem);
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.9);
+  letter-spacing: 0.08em;
+}
+
+@media (max-width: 480px) {
+  .loading-card {
+    padding: 3rem 2rem 2.5rem;
+  }
+
+  .loading-spinner {
+    margin-bottom: 2rem;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,72 @@
-import React from 'react';
-import logo from './logo.svg';
+import React, { useEffect, useMemo, useState } from 'react';
 import './App.css';
 
+const LOADING_DURATION_MS = 3 * 60 * 1000;
+
+const formatTime = (milliseconds: number): string => {
+  const remainingSeconds = Math.ceil(milliseconds / 1000);
+  const minutes = Math.floor(remainingSeconds / 60);
+  const seconds = remainingSeconds % 60;
+
+  const paddedMinutes = minutes.toString().padStart(2, '0');
+  const paddedSeconds = seconds.toString().padStart(2, '0');
+
+  return `${paddedMinutes}:${paddedSeconds}`;
+};
+
 function App() {
+  const [remainingTime, setRemainingTime] = useState<number>(LOADING_DURATION_MS);
+
+  useEffect(() => {
+    const startTime = Date.now();
+
+    const intervalId = window.setInterval(() => {
+      const elapsed = Date.now() - startTime;
+      const nextRemainingTime = Math.max(LOADING_DURATION_MS - elapsed, 0);
+
+      setRemainingTime(nextRemainingTime);
+
+      if (elapsed >= LOADING_DURATION_MS) {
+        window.clearInterval(intervalId);
+      }
+    }, 1000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  const progress = useMemo(() => {
+    const rawProgress = 1 - remainingTime / LOADING_DURATION_MS;
+    if (!Number.isFinite(rawProgress)) {
+      return 0;
+    }
+
+    return Math.min(Math.max(rawProgress, 0), 1);
+  }, [remainingTime]);
+
+  const isComplete = remainingTime === 0;
+  const statusText = isComplete ? 'آماده شد' : 'در حال بارگذاری...';
+  const subtitleText = isComplete
+    ? 'با تشکر از شکیبایی شما'
+    : 'لطفاً کمی صبر کنید، یک تجربه‌ی ویژه در راه است.';
+
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
+    <div className="app-shell">
+      <div className="gradient-layer" aria-hidden="true" />
+      <div className="loading-card" role="status" aria-live="polite">
+        <div className="loading-spinner" aria-hidden="true">
+          <div className="spinner-core" />
+        </div>
+        <p className="loading-title">{statusText}</p>
+        <p className="loading-subtitle">{subtitleText}</p>
+        <div className="progress-track" aria-hidden="true">
+          <div className="progress-bar" style={{ width: `${progress * 100}%` }} />
+        </div>
+        <p className="time-remaining" aria-label={`زمان باقی‌مانده ${formatTime(remainingTime)}`}>
+          {formatTime(remainingTime)}
         </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the default React boilerplate with a full-screen Persian loading screen featuring an animated mesh-gradient background
- add timed countdown logic to keep the loader visible for three minutes with localized messaging, spinner, and progress bar

## Testing
- npm test -- --watchAll=false *(fails: react-scripts is unavailable because the npm registry cannot be reached in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d15bb298d88327b39c85c703ec2131