### PR TITLE
Add dynamic loading indicator and refresh mesh background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,19 +1,19 @@
 @property --g1x {
   syntax: '<percentage>';
   inherits: false;
-  initial-value: 20%;
+  initial-value: 18%;
 }
 
 @property --g1y {
   syntax: '<percentage>';
   inherits: false;
-  initial-value: 30%;
+  initial-value: 22%;
 }
 
 @property --g2x {
   syntax: '<percentage>';
   inherits: false;
-  initial-value: 80%;
+  initial-value: 68%;
 }
 
 @property --g2y {
@@ -25,20 +25,80 @@
 @property --g3x {
   syntax: '<percentage>';
   inherits: false;
-  initial-value: 50%;
+  initial-value: 42%;
 }
 
 @property --g3y {
   syntax: '<percentage>';
   inherits: false;
-  initial-value: 50%;
+  initial-value: 65%;
+}
+
+@property --g4x {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 82%;
+}
+
+@property --g4y {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 30%;
+}
+
+@property --g5x {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 28%;
+}
+
+@property --g5y {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 78%;
+}
+
+@property --g6x {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 55%;
+}
+
+@property --g6y {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 32%;
+}
+
+@property --g7x {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 12%;
+}
+
+@property --g7y {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 58%;
+}
+
+@property --g8x {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 72%;
+}
+
+@property --g8y {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 12%;
 }
 
 .App {
   min-height: 100vh;
   font-family: 'Vazirmatn', 'IRANSans', 'Tahoma', sans-serif;
-  color: #f8fbff;
-  background-color: #020617;
+  color: #1f2937;
+  background-color: #f8fafc;
 }
 
 .loading-container {
@@ -48,23 +108,31 @@
   justify-content: center;
   min-height: 100vh;
   overflow: hidden;
-  background: radial-gradient(45% 45% at var(--g1x) var(--g1y), rgba(71, 111, 255, 0.65), transparent 70%),
-    radial-gradient(35% 35% at var(--g2x) var(--g2y), rgba(20, 184, 166, 0.55), transparent 70%),
-    radial-gradient(40% 40% at var(--g3x) var(--g3y), rgba(56, 189, 248, 0.45), transparent 70%),
-    #020617;
-  animation: gradientFlow 36s ease-in-out infinite alternate;
+  background:
+    radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(255, 221, 244, 0.85), transparent 75%),
+    radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(255, 244, 214, 0.9), transparent 72%),
+    radial-gradient(35% 35% at var(--g3x) var(--g3y), rgba(214, 237, 255, 0.85), transparent 70%),
+    radial-gradient(45% 45% at var(--g4x) var(--g4y), rgba(255, 231, 218, 0.85), transparent 72%),
+    radial-gradient(32% 32% at var(--g5x) var(--g5y), rgba(230, 255, 242, 0.9), transparent 70%),
+    radial-gradient(28% 28% at var(--g6x) var(--g6y), rgba(255, 230, 240, 0.8), transparent 72%),
+    radial-gradient(40% 40% at var(--g7x) var(--g7y), rgba(222, 241, 255, 0.75), transparent 70%),
+    radial-gradient(34% 34% at var(--g8x) var(--g8y), rgba(255, 248, 224, 0.8), transparent 70%),
+    radial-gradient(60% 60% at 50% 50%, rgba(255, 255, 255, 0.8), rgba(248, 250, 252, 0.9));
+  animation: gradientFlow 22s ease-in-out infinite alternate;
 }
 
 .loading-container::before {
   content: '';
   position: absolute;
-  inset: -20%;
-  background: radial-gradient(800px circle at 20% 20%, rgba(59, 130, 246, 0.35), transparent 70%),
-    radial-gradient(900px circle at 80% 70%, rgba(20, 184, 166, 0.3), transparent 70%),
-    radial-gradient(650px circle at 50% 40%, rgba(14, 165, 233, 0.3), transparent 70%);
-  filter: blur(60px);
-  opacity: 0.9;
-  animation: auroraDrift 48s ease-in-out infinite alternate;
+  inset: -18%;
+  background:
+    radial-gradient(720px circle at 20% 18%, rgba(255, 210, 234, 0.7), transparent 72%),
+    radial-gradient(840px circle at 78% 72%, rgba(255, 239, 207, 0.6), transparent 72%),
+    radial-gradient(680px circle at 52% 40%, rgba(209, 231, 255, 0.65), transparent 72%),
+    radial-gradient(560px circle at 30% 80%, rgba(213, 255, 235, 0.55), transparent 75%);
+  filter: blur(55px);
+  opacity: 0.95;
+  animation: auroraDrift 26s ease-in-out infinite alternate;
   z-index: 0;
 }
 
@@ -72,38 +140,100 @@
   position: relative;
   z-index: 1;
   text-align: center;
-  padding: 3rem;
-  backdrop-filter: blur(18px) saturate(130%);
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 64, 175, 0.35));
-  border-radius: 32px;
-  box-shadow: 0 40px 120px rgba(15, 23, 42, 0.65);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: clamp(2.5rem, 6vw, 4rem);
+  backdrop-filter: blur(22px) saturate(160%);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.86), rgba(255, 244, 244, 0.8));
+  border-radius: 36px;
+  box-shadow: 0 30px 110px rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(226, 232, 240, 0.6);
   direction: rtl;
 }
 
-.spinner {
-  width: clamp(96px, 12vw, 140px);
-  height: clamp(96px, 12vw, 140px);
+.progress-indicator {
+  --progress: 0;
+  position: relative;
+  width: clamp(120px, 14vw, 170px);
+  height: clamp(120px, 14vw, 170px);
+  margin: 0 auto clamp(1.8rem, 4vw, 2.4rem);
   border-radius: 50%;
-  border: 6px solid rgba(148, 163, 184, 0.3);
-  border-top-color: #38bdf8;
-  border-right-color: rgba(14, 165, 233, 0.6);
-  animation: spin 1.6s linear infinite;
-  margin: 0 auto 2.5rem;
-  box-shadow: 0 0 35px rgba(56, 189, 248, 0.4);
+  background: conic-gradient(
+      rgba(255, 140, 105, 0.9) calc(var(--progress) * 1%),
+      rgba(255, 255, 255, 0.5) calc(var(--progress) * 1%)
+    ),
+    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.85), rgba(255, 244, 244, 0.65));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 20px 50px rgba(255, 173, 135, 0.35);
+  transition: background 220ms ease-out;
+}
+
+.progress-indicator::after {
+  content: '';
+  position: absolute;
+  inset: 10%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.95), rgba(255, 244, 244, 0.7));
+  box-shadow: inset 0 12px 24px rgba(148, 163, 184, 0.15);
+}
+
+.progress-indicator__inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 0.35rem;
+  color: #fb7185;
+  font-weight: 700;
+}
+
+.progress-indicator__value {
+  font-size: clamp(2.8rem, 6vw, 3.6rem);
+  line-height: 1;
+}
+
+.progress-indicator__suffix {
+  font-size: clamp(1.2rem, 2.6vw, 1.6rem);
+  margin-bottom: 0.35rem;
 }
 
 .loading-text {
-  font-size: clamp(2.4rem, 4vw, 4rem);
+  font-size: clamp(2.2rem, 4vw, 3.6rem);
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
   margin: 0 0 1rem;
+  color: #334155;
 }
 
 .loading-subtext {
-  font-size: clamp(1.1rem, 2vw, 1.6rem);
+  font-size: clamp(1.15rem, 2.3vw, 1.6rem);
+  margin: 0 0 1.5rem;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.progress-track {
+  width: min(380px, 70vw);
+  height: 14px;
+  margin: 0 auto 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: inset 0 4px 12px rgba(148, 163, 184, 0.4);
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(255, 183, 142, 0.95), rgba(255, 105, 180, 0.9));
+  box-shadow: 0 6px 14px rgba(236, 72, 153, 0.25);
+  transition: width 320ms cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.progress-note {
   margin: 0;
-  color: rgba(226, 232, 240, 0.85);
+  font-size: clamp(0.95rem, 2vw, 1.2rem);
+  color: rgba(71, 85, 105, 0.7);
 }
 
 .loaded-message {
@@ -112,10 +242,11 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.3), transparent 70%),
-    radial-gradient(circle at 80% 80%, rgba(6, 182, 212, 0.2), transparent 70%),
-    #020617;
-  color: #f8fafc;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 237, 213, 0.65), transparent 72%),
+    radial-gradient(circle at 78% 78%, rgba(224, 242, 254, 0.6), transparent 70%),
+    #f8fafc;
+  color: #1f2937;
   text-align: center;
   padding: 2rem;
   gap: 1rem;
@@ -124,55 +255,80 @@
 .loaded-message h1 {
   font-size: clamp(2.4rem, 5vw, 3.5rem);
   margin: 0;
+  color: #334155;
 }
 
 .loaded-message p {
   margin: 0;
   font-size: clamp(1.1rem, 2.2vw, 1.6rem);
-  color: rgba(226, 232, 240, 0.8);
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+  color: rgba(71, 85, 105, 0.78);
 }
 
 @keyframes gradientFlow {
   0% {
-    --g1x: 18%;
-    --g1y: 28%;
-    --g2x: 78%;
-    --g2y: 72%;
-    --g3x: 52%;
-    --g3y: 45%;
+    --g1x: 16%;
+    --g1y: 18%;
+    --g2x: 70%;
+    --g2y: 78%;
+    --g3x: 40%;
+    --g3y: 62%;
+    --g4x: 86%;
+    --g4y: 28%;
+    --g5x: 20%;
+    --g5y: 80%;
+    --g6x: 50%;
+    --g6y: 34%;
+    --g7x: 15%;
+    --g7y: 55%;
+    --g8x: 74%;
+    --g8y: 18%;
   }
   50% {
-    --g1x: 30%;
-    --g1y: 40%;
-    --g2x: 70%;
-    --g2y: 60%;
-    --g3x: 60%;
-    --g3y: 55%;
+    --g1x: 28%;
+    --g1y: 32%;
+    --g2x: 64%;
+    --g2y: 64%;
+    --g3x: 58%;
+    --g3y: 48%;
+    --g4x: 74%;
+    --g4y: 44%;
+    --g5x: 36%;
+    --g5y: 68%;
+    --g6x: 58%;
+    --g6y: 42%;
+    --g7x: 22%;
+    --g7y: 62%;
+    --g8x: 66%;
+    --g8y: 26%;
   }
   100% {
-    --g1x: 22%;
-    --g1y: 70%;
-    --g2x: 85%;
-    --g2y: 30%;
-    --g3x: 45%;
-    --g3y: 65%;
+    --g1x: 20%;
+    --g1y: 68%;
+    --g2x: 78%;
+    --g2y: 36%;
+    --g3x: 46%;
+    --g3y: 72%;
+    --g4x: 88%;
+    --g4y: 20%;
+    --g5x: 28%;
+    --g5y: 58%;
+    --g6x: 48%;
+    --g6y: 28%;
+    --g7x: 10%;
+    --g7y: 48%;
+    --g8x: 82%;
+    --g8y: 16%;
   }
 }
 
 @keyframes auroraDrift {
   0% {
-    transform: translate3d(-2%, -1%, 0) scale(1.05);
+    transform: translate3d(-3%, -2%, 0) scale(1.05);
   }
   50% {
-    transform: translate3d(2%, 3%, 0) scale(1.1);
+    transform: translate3d(3%, 4%, 0) scale(1.12);
   }
   100% {
-    transform: translate3d(-3%, 2%, 0) scale(1.08);
+    transform: translate3d(-4%, 3%, 0) scale(1.08);
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,88 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './App.css';
 
 const LOADING_DURATION_MS = 180_000;
 
 function App() {
   const [isLoading, setIsLoading] = useState(true);
+  const [progress, setProgress] = useState(0);
+  const progressRef = useRef(0);
 
   useEffect(() => {
     const timer = window.setTimeout(() => setIsLoading(false), LOADING_DURATION_MS);
     return () => window.clearTimeout(timer);
   }, []);
 
+  useEffect(() => {
+    const startTime = performance.now();
+    let timeoutId: number;
+
+    const updateProgress = () => {
+      const now = performance.now();
+      const elapsed = now - startTime;
+      const normalized = Math.min(elapsed / LOADING_DURATION_MS, 1);
+      const eased = 1 - Math.pow(1 - normalized, 3);
+      const wave = Math.sin(now / 1800) * 0.08 + Math.sin(now / 3100 + 1.2) * 0.06;
+      const jitter = (Math.random() - 0.5) * 0.06;
+
+      const projected = (eased + wave + jitter) * 100;
+      const maxAllowed = normalized * 100 + 12;
+      const minAllowed = normalized * 100 - 14;
+
+      const nextValue = Math.max(
+        Math.min(projected, maxAllowed, progressRef.current + 5.5, 99.5),
+        Math.max(minAllowed, progressRef.current + 0.25)
+      );
+
+      progressRef.current = Number(nextValue.toFixed(2));
+      setProgress(progressRef.current);
+
+      const delay = 160 + Math.random() * 520;
+      timeoutId = window.setTimeout(updateProgress, delay);
+    };
+
+    timeoutId = window.setTimeout(updateProgress, 280);
+
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  useEffect(() => {
+    if (!isLoading) {
+      progressRef.current = 100;
+      setProgress(100);
+    }
+  }, [isLoading]);
+
+  const progressValue = Math.min(100, Math.round(progress));
+  const progressIndicatorStyle = {
+    '--progress': progress.toFixed(2),
+  } as React.CSSProperties;
+
   return (
     <div className="App">
       {isLoading ? (
         <div className="loading-container" role="status" aria-live="polite">
           <div className="loading-content">
-            <div className="spinner" aria-hidden="true" />
+            <div
+              className="progress-indicator"
+              style={progressIndicatorStyle}
+              role="progressbar"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={progressValue}
+              aria-valuetext={`${progressValue} درصد تکمیل`}
+            >
+              <div className="progress-indicator__inner">
+                <span className="progress-indicator__value">{progressValue}</span>
+                <span className="progress-indicator__suffix">%</span>
+              </div>
+            </div>
             <p className="loading-text">در حال بارگذاری...</p>
             <p className="loading-subtext">لطفاً تا آماده شدن سامانه شکیبا باشید.</p>
+            <div className="progress-track" aria-hidden="true">
+              <div className="progress-bar" style={{ width: `${progress}%` }} />
+            </div>
+            <p className="progress-note">در این میان می‌توانید به یک فنجان چای فکر کنید.</p>
           </div>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- add a percent-based loading indicator with variable pacing and accessible progress display
- refresh the loading view with a faster, pastel mesh gradient background and supporting styles
- align the post-load state styling with the lighter color palette

## Testing
- npm run build *(fails: `react-scripts` command cannot be resolved by npm in this environment even after reinstalling dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d163799bec8327990038560ab91c19