### PR TITLE
Make loading gradient bolder and pause timer when page hidden

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -48,9 +48,9 @@
   justify-content: center;
   min-height: 100vh;
   overflow: hidden;
-  background: radial-gradient(45% 45% at var(--g1x) var(--g1y), rgba(71, 111, 255, 0.65), transparent 70%),
-    radial-gradient(35% 35% at var(--g2x) var(--g2y), rgba(20, 184, 166, 0.55), transparent 70%),
-    radial-gradient(40% 40% at var(--g3x) var(--g3y), rgba(56, 189, 248, 0.45), transparent 70%),
+  background: radial-gradient(45% 45% at var(--g1x) var(--g1y), rgba(71, 111, 255, 0.85), transparent 70%),
+    radial-gradient(35% 35% at var(--g2x) var(--g2y), rgba(20, 184, 166, 0.75), transparent 70%),
+    radial-gradient(40% 40% at var(--g3x) var(--g3y), rgba(56, 189, 248, 0.65), transparent 70%),
     #020617;
   animation: gradientFlow 36s ease-in-out infinite alternate;
 }
@@ -59,9 +59,9 @@
   content: '';
   position: absolute;
   inset: -20%;
-  background: radial-gradient(800px circle at 20% 20%, rgba(59, 130, 246, 0.35), transparent 70%),
-    radial-gradient(900px circle at 80% 70%, rgba(20, 184, 166, 0.3), transparent 70%),
-    radial-gradient(650px circle at 50% 40%, rgba(14, 165, 233, 0.3), transparent 70%);
+  background: radial-gradient(800px circle at 20% 20%, rgba(59, 130, 246, 0.55), transparent 70%),
+    radial-gradient(900px circle at 80% 70%, rgba(20, 184, 166, 0.5), transparent 70%),
+    radial-gradient(650px circle at 50% 40%, rgba(14, 165, 233, 0.5), transparent 70%);
   filter: blur(60px);
   opacity: 0.9;
   animation: auroraDrift 48s ease-in-out infinite alternate;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './App.css';
 
 const LOADING_DURATION_MS = 180_000;
@@ -6,10 +6,72 @@ const LOADING_DURATION_MS = 180_000;
 function App() {
   const [isLoading, setIsLoading] = useState(true);
 
+  const remainingTimeRef = useRef(LOADING_DURATION_MS);
+  const timerRef = useRef<number | null>(null);
+  const lastStartRef = useRef<number | null>(null);
+
   useEffect(() => {
-    const timer = window.setTimeout(() => setIsLoading(false), LOADING_DURATION_MS);
-    return () => window.clearTimeout(timer);
-  }, []);
+    if (!isLoading) {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+
+    const clearTimer = () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+
+    const pauseTimer = () => {
+      if (lastStartRef.current !== null) {
+        const elapsed = Date.now() - lastStartRef.current;
+        remainingTimeRef.current = Math.max(remainingTimeRef.current - elapsed, 0);
+        lastStartRef.current = null;
+      }
+      clearTimer();
+    };
+
+    const completeLoading = () => {
+      remainingTimeRef.current = 0;
+      lastStartRef.current = null;
+      setIsLoading(false);
+    };
+
+    const startTimer = () => {
+      if (remainingTimeRef.current <= 0) {
+        completeLoading();
+        return;
+      }
+
+      lastStartRef.current = Date.now();
+      clearTimer();
+      timerRef.current = window.setTimeout(completeLoading, remainingTimeRef.current);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        pauseTimer();
+      } else {
+        startTimer();
+      }
+    };
+
+    if (document.hidden) {
+      pauseTimer();
+    } else {
+      startTimer();
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      pauseTimer();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isLoading]);
 
   return (
     <div className="App">


### PR DESCRIPTION
## Summary
- intensify mesh gradient overlays to make the loading screen visuals more pronounced
- ensure the loading countdown pauses when the tab becomes hidden and resumes on return

## Testing
- npm test -- --watchAll=false *(fails: react-scripts missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17553f6e08327be3417df3d6c36ca