### PR TITLE
Make loading screen funnier and add Rubik font

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap');
+
 @property --g1x {
   syntax: '<percentage>';
   inherits: false;
@@ -96,7 +98,7 @@
 
 .App {
   min-height: 100vh;
-  font-family: 'Vazirmatn', 'IRANSans', 'Tahoma', sans-serif;
+  font-family: 'Rubik', 'Vazirmatn', 'IRANSans', 'Tahoma', sans-serif;
   color: #1f2937;
   background-color: #f8fafc;
 }
@@ -231,9 +233,15 @@
 }
 
 .progress-note {
+  margin: 0 0 0.5rem;
+  font-size: clamp(0.98rem, 2.1vw, 1.24rem);
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.progress-footnote {
   margin: 0;
-  font-size: clamp(0.95rem, 2vw, 1.2rem);
-  color: rgba(71, 85, 105, 0.7);
+  font-size: clamp(0.85rem, 1.8vw, 1.08rem);
+  color: rgba(100, 116, 139, 0.7);
 }
 
 .loaded-message {
@@ -262,6 +270,17 @@
   margin: 0;
   font-size: clamp(1.1rem, 2.2vw, 1.6rem);
   color: rgba(71, 85, 105, 0.78);
+  max-width: min(620px, 90vw);
+}
+
+.wasted-duration {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  margin-inline: 0.15rem;
+  border-radius: 999px;
+  background: rgba(255, 105, 180, 0.12);
+  color: #be123c;
+  font-weight: 600;
 }
 
 @keyframes gradientFlow {

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@ body,
 
 body {
   margin: 0;
-  font-family: 'Vazirmatn', 'IRANSans', 'Tahoma', sans-serif;
+  font-family: 'Rubik', 'Vazirmatn', 'IRANSans', 'Tahoma', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #020617;


### PR DESCRIPTION
## Summary
- load Google Rubik font globally and refresh typography accents
- rewrite loading copy with comedic Persian messaging focused on a bicycle
- show wasted time duration in Persian digits once loading completes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d17b56b7688327a90735ee2f268fbf