### PR TITLE
Add confetti celebration after loading completes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "react": "^19.1.1",
+        "react-confetti": "^6.4.0",
         "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
@@ -13822,6 +13823,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -16248,6 +16264,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
+      "license": "BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "react": "^19.1.1",
+    "react-confetti": "^6.4.0",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",

--- a/src/App.css
+++ b/src/App.css
@@ -105,6 +105,13 @@
   overflow: hidden;
 }
 
+.confetti-canvas {
+  position: fixed !important;
+  inset: 0 !important;
+  pointer-events: none;
+  z-index: 0 !important;
+}
+
 .loading-container {
   position: relative;
   display: flex;
@@ -248,6 +255,8 @@
 }
 
 .loaded-message {
+  position: relative;
+  z-index: 1;
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import Confetti from 'react-confetti';
 import './App.css';
 import { TIME_QUOTES } from './timeQuotes';
 
@@ -15,6 +16,11 @@ const shuffleArray = <T,>(items: readonly T[]) => {
   }
   return cloned;
 };
+
+const getWindowSize = () =>
+  typeof window === 'undefined'
+    ? { width: 0, height: 0 }
+    : { width: window.innerWidth, height: window.innerHeight };
 
 const toPersianDigits = (value: number) =>
   value
@@ -44,6 +50,7 @@ function App() {
   const quotePointerRef = useRef(0);
   const quoteIntervalRef = useRef<number | null>(null);
   const quoteFadeTimeoutRef = useRef<number | null>(null);
+  const [windowSize, setWindowSize] = useState(getWindowSize);
 
   useEffect(() => {
     const timer = window.setTimeout(() => setIsLoading(false), LOADING_DURATION_MS);
@@ -166,6 +173,11 @@ function App() {
       return undefined;
     }
 
+    if (!isLoading) {
+      setIsQuoteVisible(false);
+      return undefined;
+    }
+
     const indexes = TIME_QUOTES.map((_, index) => index);
     quoteOrderRef.current = shuffleArray(indexes);
     quotePointerRef.current = 0;
@@ -202,16 +214,38 @@ function App() {
         window.clearTimeout(quoteFadeTimeoutRef.current);
       }
     };
+  }, [isLoading]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize(getWindowSize());
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   const progressValue = Math.min(100, Math.round(progress));
   const progressIndicatorStyle = {
     '--progress': progress.toFixed(2),
   } as React.CSSProperties;
-  const activeQuote = TIME_QUOTES[currentQuoteIndex];
+  const activeQuote = isLoading ? TIME_QUOTES[currentQuoteIndex] : undefined;
+  const showConfetti = !isLoading;
 
   return (
     <div className="App">
+      {showConfetti ? (
+        <Confetti
+          className="confetti-canvas"
+          width={windowSize.width}
+          height={windowSize.height}
+          numberOfPieces={280}
+          recycle
+          run
+        />
+      ) : null}
       {isLoading ? (
         <div className="loading-container" role="status" aria-live="polite">
           <div className="loading-content">


### PR DESCRIPTION
## Summary
- add a confetti celebration that runs continuously after loading finishes
- limit the rotating quotes to the loading state and track viewport size for the confetti canvas
- update styles so the confetti animation stays behind the loaded message content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d18414fa448327b291790ac290579f