### PR TITLE
Add code-themed loader overlay and confetti celebration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "react": "^19.1.1",
+        "react-confetti": "^6.4.0",
         "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
@@ -13822,6 +13823,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -16248,6 +16264,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
+      "license": "BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "react": "^19.1.1",
+    "react-confetti": "^6.4.0",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",

--- a/src/App.css
+++ b/src/App.css
@@ -125,6 +125,58 @@
   animation: gradientFlow 22s ease-in-out infinite alternate;
 }
 
+.code-background {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 5vw, 4rem);
+  pointer-events: none;
+  opacity: 0.42;
+  z-index: 0;
+}
+
+.code-background::before {
+  content: '';
+  position: absolute;
+  inset: -25%;
+  background: radial-gradient(circle at 50% 50%, rgba(15, 23, 42, 0.2), transparent 70%);
+  filter: blur(30px);
+  opacity: 0.65;
+}
+
+.code-background__inner {
+  position: relative;
+  display: grid;
+  gap: clamp(0.45rem, 1.6vw, 0.9rem);
+  font-family: 'Fira Code', 'Source Code Pro', 'Courier New', monospace;
+  font-size: clamp(0.75rem, 1.4vw, 1rem);
+  color: rgba(15, 23, 42, 0.82);
+  filter: drop-shadow(0 12px 24px rgba(15, 23, 42, 0.16));
+}
+
+.code-line {
+  position: relative;
+  padding: 0.35rem 0.75rem;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(248, 250, 252, 0.78), rgba(255, 255, 255, 0.58));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 18px 35px rgba(148, 163, 184, 0.25);
+  letter-spacing: 0.02em;
+  animation: codePulse 6.8s ease-in-out infinite;
+}
+
+.code-line::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0));
+  opacity: 0;
+  animation-delay: inherit;
+  animation: codeBlink 5s linear infinite;
+}
+
 .loading-container::before {
   content: '';
   position: absolute;
@@ -253,6 +305,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  position: relative;
+  z-index: 1;
   background:
     radial-gradient(circle at 20% 20%, rgba(255, 237, 213, 0.65), transparent 72%),
     radial-gradient(circle at 78% 78%, rgba(224, 242, 254, 0.6), transparent 70%),
@@ -262,6 +316,19 @@
   padding: 2rem;
   gap: 1rem;
   animation: softFade 900ms ease both;
+}
+
+.loaded-message > * {
+  position: relative;
+  z-index: 1;
+}
+
+.loaded-message::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 30%, rgba(254, 226, 226, 0.28), transparent 65%);
+  z-index: 0;
 }
 
 .loaded-message h1 {
@@ -331,6 +398,29 @@
 .quote-banner__author {
   font-weight: 600;
   color: #fde68a;
+}
+
+@keyframes codePulse {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 0.88;
+  }
+  50% {
+    transform: translateY(-6px) scale(1.02);
+    opacity: 1;
+  }
+}
+
+@keyframes codeBlink {
+  0%,
+  95%,
+  100% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 0.7;
+  }
 }
 
 @keyframes gradientFlow {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('نمایش پیام جدی بارگذاری', () => {
+test('نمایش پیام بارگذاری و نمایش کدها', () => {
   render(<App />);
-  const loadingText = screen.getByText('لطفاً آرام بمانید و چشم از صفحه برندارید.');
+  const loadingText = screen.getByText(/نفستو نگه دار؛ رمز به زودی لو می‌ره/);
   expect(loadingText).toBeInTheDocument();
+  expect(screen.getAllByText(/return/)[0]).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add a code-themed backdrop to the loading state so only the loader shows code while waiting
- trigger a persistent confetti celebration once loading completes and report viewport changes
- adjust styles and tests to support the new presentation and dependency

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d18414fa448327b291790ac290579f