### PR TITLE
Add infinite confetti celebration after loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^16.18.126",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
+        "canvas-confetti": "^1.9.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",
@@ -5521,6 +5522,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^16.18.126",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
+    "canvas-confetti": "^1.9.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",

--- a/src/App.css
+++ b/src/App.css
@@ -105,6 +105,21 @@
   overflow: hidden;
 }
 
+.confetti-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 600ms ease;
+  z-index: 0;
+}
+
+.confetti-canvas--active {
+  opacity: 1;
+}
+
 .loading-container {
   position: relative;
   display: flex;
@@ -112,6 +127,7 @@
   justify-content: center;
   min-height: 100vh;
   overflow: hidden;
+  z-index: 1;
   background:
     radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(255, 221, 244, 0.96), transparent 76%),
     radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(255, 244, 214, 0.98), transparent 74%),
@@ -248,6 +264,8 @@
 }
 
 .loaded-message {
+  position: relative;
+  z-index: 1;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -301,6 +319,7 @@
   opacity: 0;
   transition: opacity 900ms ease, transform 900ms ease;
   backdrop-filter: blur(14px) saturate(160%);
+  z-index: 2;
 }
 
 .quote-banner--visible {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,6 +4,6 @@ import App from './App';
 
 test('نمایش پیام جدی بارگذاری', () => {
   render(<App />);
-  const loadingText = screen.getByText('لطفاً آرام بمانید و چشم از صفحه برندارید.');
+  const loadingText = screen.getByText('نفستو نگه دار؛ رمز به زودی لو می‌ره...');
   expect(loadingText).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add a canvas-confetti background that plays continuously after loading completes
- limit quotes and progress indicator to the loading phase and adjust styling for the new confetti canvas
- update the loading message test to match the displayed copy

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d18414fa448327b291790ac290579f