### PR TITLE
Add celebratory confetti after loading completes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "react": "^19.1.1",
+        "react-confetti": "^6.4.0",
         "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
@@ -13822,6 +13823,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -16248,6 +16264,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
+      "license": "BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "react": "^19.1.1",
+    "react-confetti": "^6.4.0",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",

--- a/src/App.css
+++ b/src/App.css
@@ -247,20 +247,42 @@
   color: rgba(100, 116, 139, 0.7);
 }
 
-.loaded-message {
+.loaded-state {
+  position: relative;
   min-height: 100vh;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
+  padding: 2rem;
+  overflow: hidden;
   background:
     radial-gradient(circle at 20% 20%, rgba(255, 237, 213, 0.65), transparent 72%),
     radial-gradient(circle at 78% 78%, rgba(224, 242, 254, 0.6), transparent 70%),
     #f8fafc;
-  color: #1f2937;
+}
+
+.confetti-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.loaded-message {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
+  color: #1f2937;
   padding: 2rem;
   gap: 1rem;
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 32px;
+  box-shadow: 0 30px 110px rgba(148, 163, 184, 0.35);
+  backdrop-filter: blur(14px) saturate(140%);
   animation: softFade 900ms ease both;
 }
 


### PR DESCRIPTION
## Summary
- add react-confetti to create a looping celebratory backdrop after loading completes
- hide rotating quotes once loading is done and restore the requested loading subtext message
- restyle the loaded state container so the confetti layer can sit behind the final message

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d18414fa448327b291790ac290579f