### PR TITLE
Adjust loading duration to 3.5 minutes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import Confetti from 'react-confetti';
 import './App.css';
 import { TIME_QUOTES } from './timeQuotes';
 
-const LOADING_DURATION_MS = 180_000;
+const LOADING_DURATION_MS = 210_000;
 const PERSIAN_DIGITS = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
 const QUOTE_DISPLAY_DURATION_MS = 10_000;
 const QUOTE_FADE_DURATION_MS = 1_000;


### PR DESCRIPTION
## Summary
- increase the loading duration to 210 seconds (3.5 minutes) to keep the waiting time between three and four minutes

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d18b701fdc8327922ecbe057cab15b