### PR TITLE
Randomize loading duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,21 +3,33 @@
 # dependencies
 /node_modules
 /.pnp
+.pnp.cjs
+.pnp.loader.mjs
 .pnp.js
+/yarn.lock
 
 # testing
 /coverage
+/.nyc_output
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store
+.idea/
+.vscode/
+.env
 .env.local
 .env.development.local
 .env.test.local
 .env.production.local
+.eslintcache
+*.tsbuildinfo
+*.log
 
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*

--- a/src/App.css
+++ b/src/App.css
@@ -105,6 +105,37 @@
   overflow: hidden;
 }
 
+.elapsed-counter {
+  position: fixed;
+  top: clamp(1rem, 3vw, 1.75rem);
+  right: clamp(1rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+  border-radius: 18px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(14px) saturate(160%);
+  direction: rtl;
+  z-index: 4;
+  font-feature-settings: 'tnum' on;
+}
+
+.elapsed-counter__label {
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+  opacity: 0.85;
+}
+
+.elapsed-counter__value {
+  font-size: clamp(1.4rem, 3vw, 1.8rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
 .loading-container {
   position: relative;
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -250,10 +250,10 @@ function App() {
 
   return (
     <div className="App">
-      <div className="elapsed-counter" aria-live="polite">
-        <span className="elapsed-counter__label">زمان سپری‌شده</span>
-        <span className="elapsed-counter__value">{formattedElapsed}</span>
-      </div>
+      {/*<div className="elapsed-counter" aria-live="polite">*/}
+      {/*  <span className="elapsed-counter__label">زمان سپری‌شده</span>*/}
+      {/*  <span className="elapsed-counter__value">{formattedElapsed}</span>*/}
+      {/*</div>*/}
       {isLoading ? (
         <div className="loading-container" role="status" aria-live="polite">
           <div className="loading-content">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,8 @@ import Confetti from 'react-confetti';
 import './App.css';
 import { TIME_QUOTES } from './timeQuotes';
 
-const LOADING_DURATION_MS = 210_000;
+const MIN_LOADING_DURATION_MS = 180_000;
+const MAX_LOADING_DURATION_MS = 240_000;
 const PERSIAN_DIGITS = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
 const QUOTE_DISPLAY_DURATION_MS = 10_000;
 const QUOTE_FADE_DURATION_MS = 1_000;
@@ -39,6 +40,10 @@ const getWindowSize = () => ({
 });
 
 function App() {
+  const loadingDurationMs = React.useMemo(
+    () => Math.round(MIN_LOADING_DURATION_MS + Math.random() * (MAX_LOADING_DURATION_MS - MIN_LOADING_DURATION_MS)),
+    []
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [progress, setProgress] = useState(0);
   const [elapsedMs, setElapsedMs] = useState<number | null>(null);
@@ -53,9 +58,9 @@ function App() {
   const quoteFadeTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const timer = window.setTimeout(() => setIsLoading(false), LOADING_DURATION_MS);
+    const timer = window.setTimeout(() => setIsLoading(false), loadingDurationMs);
     return () => window.clearTimeout(timer);
-  }, []);
+  }, [loadingDurationMs]);
 
   const startTimeRef = useRef<number | null>(null);
   const pausedDurationRef = useRef(0);
@@ -84,7 +89,7 @@ function App() {
       const now = performance.now();
       const startTime = startTimeRef.current ?? now;
       const elapsed = now - startTime - pausedDurationRef.current;
-      const normalized = Math.min(elapsed / LOADING_DURATION_MS, 1);
+      const normalized = Math.min(elapsed / loadingDurationMs, 1);
       const eased = 1 - Math.pow(1 - normalized, 3);
       const wave = Math.sin(now / 1800) * 0.08 + Math.sin(now / 3100 + 1.2) * 0.06;
       const jitter = (Math.random() - 0.5) * 0.06;
@@ -153,7 +158,7 @@ function App() {
       window.removeEventListener('blur', handleBlur);
       window.removeEventListener('focus', handleFocus);
     };
-  }, []);
+  }, [loadingDurationMs]);
 
   useEffect(() => {
     if (!isLoading) {
@@ -162,11 +167,11 @@ function App() {
       setProgress(100);
 
       const now = performance.now();
-      const startTime = startTimeRef.current ?? now - LOADING_DURATION_MS;
+      const startTime = startTimeRef.current ?? now - loadingDurationMs;
       const totalElapsed = now - startTime - pausedDurationRef.current;
       setElapsedMs(totalElapsed);
     }
-  }, [isLoading]);
+  }, [isLoading, loadingDurationMs]);
 
   useEffect(() => {
     const handleResize = () => setWindowSize(getWindowSize());
@@ -266,7 +271,7 @@ function App() {
           <div className="loaded-message">
             <bdi>
               همین حالا{' '}
-              <bdi className="wasted-duration">{formatDuration(elapsedMs ?? LOADING_DURATION_MS)}</bdi>{' '}
+              <bdi className="wasted-duration">{formatDuration(elapsedMs ?? loadingDurationMs)}</bdi>{' '}
               از عمرت دود شد.
             </bdi>
             <bdi>حالا رفرش کن :)</bdi>


### PR DESCRIPTION
## Summary
- randomize the loading duration to a per-session value between three and four minutes
- keep progress animation and completion reporting in sync with the generated duration

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e68ab07f308327ad3c794fca8fc83f