### PR TITLE
Update marketing metadata for Vaghtgir landing page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fa">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -7,8 +7,42 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Vaghtgir is the immersive Persian timekeeper by Mahdi Zarei (skyBlueDev) that delights users with mindful quotes, celebratory visuals, and a premium waiting experience designed to boost anticipation and sales conversions."
     />
+    <meta
+      name="keywords"
+      content="Mahdi Zarei, skyBlueDev, Vaghtgir, Persian timer, interactive loading screen, premium waiting room, motivational quotes, sales funnel, anticipation marketing, immersive user experience"
+    />
+    <meta name="author" content="skyBlueDev" />
+    <meta name="creator" content="Mahdi Zarei (skyBlueDev)" />
+    <meta name="publisher" content="Mahdi Zarei" />
+    <meta name="application-name" content="Vaghtgir" />
+    <meta name="robots" content="index, follow" />
+    <meta name="category" content="Productivity, Mindfulness, Sales Enablement" />
+    <meta name="language" content="fa-IR" />
+    <meta name="apple-mobile-web-app-title" content="Vaghtgir" />
+    <meta name="copyright" content="© Mahdi Zarei (skyBlueDev)" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Vaghtgir | Premium Persian Time Experience by Mahdi Zarei" />
+    <meta
+      property="og:description"
+      content="Transform waiting into a premium brand moment with Vaghtgir by Mahdi Zarei (skyBlueDev)—a polished Persian timekeeping experience that captivates audiences, reinforces trust, and elevates conversions."
+    />
+    <meta property="og:site_name" content="Vaghtgir by skyBlueDev" />
+    <meta property="og:locale" content="fa_IR" />
+    <meta property="og:url" content="https://skybluedev.com/vaghtgir" />
+    <meta property="og:image" content="%PUBLIC_URL%/logo192.png" />
+    <meta property="og:image:alt" content="Vaghtgir Persian time experience by Mahdi Zarei" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Vaghtgir | Crafted by skyBlueDev" />
+    <meta
+      name="twitter:description"
+      content="Deliver a luxurious waiting journey with Vaghtgir, the signature Persian timer by Mahdi Zarei (skyBlueDev), featuring motivational quotes and delightful animations tailored for sales-ready experiences."
+    />
+    <meta name="twitter:creator" content="@skyBlueDev" />
+    <meta name="twitter:image" content="%PUBLIC_URL%/logo192.png" />
+    <meta name="twitter:image:alt" content="Vaghtgir Persian time experience by Mahdi Zarei" />
+    <link rel="canonical" href="https://skybluedev.com/vaghtgir" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -24,7 +58,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Vaghtgir | Premium Persian Time Experience by Mahdi Zarei</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Summary
- replace boilerplate metadata with sales-focused messaging under the Mahdi Zarei (skyBlueDev) brand
- add structured open graph, twitter, and SEO tags tailored for promoting the Vaghtgir experience
- set the document language and canonical URL to support discoverability for Persian-speaking audiences

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9444bad4c83278dfbb47af37882be