### PR TITLE
Implement CSS-variable theming with ripple theme transition

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -97,17 +97,132 @@
 }
 
 .App {
+  --color-scheme: light;
+  --app-text-color: #1f2937;
+  --app-background-color: #f8fafc;
+  --theme-toggle-border: rgba(15, 23, 42, 0.1);
+  --theme-toggle-background: rgba(15, 23, 42, 0.72);
+  --theme-toggle-color: #f8fafc;
+  --theme-toggle-shadow: 0 18px 30px rgba(15, 23, 42, 0.22);
+  --theme-toggle-hover-shadow: 0 20px 38px rgba(15, 23, 42, 0.28);
+  --loading-container-background:
+    radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(255, 221, 244, 0.96), transparent 76%),
+    radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(255, 244, 214, 0.98), transparent 74%),
+    radial-gradient(35% 35% at var(--g3x) var(--g3y), rgba(214, 237, 255, 0.95), transparent 72%),
+    radial-gradient(45% 45% at var(--g4x) var(--g4y), rgba(255, 231, 218, 0.95), transparent 74%),
+    radial-gradient(32% 32% at var(--g5x) var(--g5y), rgba(230, 255, 242, 0.97), transparent 72%),
+    radial-gradient(28% 28% at var(--g6x) var(--g6y), rgba(255, 230, 240, 0.94), transparent 74%),
+    radial-gradient(40% 40% at var(--g7x) var(--g7y), rgba(222, 241, 255, 0.9), transparent 72%),
+    radial-gradient(34% 34% at var(--g8x) var(--g8y), rgba(255, 248, 224, 0.92), transparent 72%),
+    radial-gradient(60% 60% at 50% 50%, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.95));
+  --loading-container-overlay:
+    radial-gradient(720px circle at 20% 18%, rgba(255, 210, 234, 0.88), transparent 74%),
+    radial-gradient(840px circle at 78% 72%, rgba(255, 239, 207, 0.82), transparent 74%),
+    radial-gradient(680px circle at 52% 40%, rgba(209, 231, 255, 0.84), transparent 74%),
+    radial-gradient(560px circle at 30% 80%, rgba(213, 255, 235, 0.8), transparent 77%);
+  --loading-container-overlay-blur: 48px;
+  --loading-container-overlay-opacity: 0.98;
+  --loading-content-background: linear-gradient(135deg, rgba(255, 255, 255, 0.86), rgba(255, 244, 244, 0.8));
+  --loading-content-border-color: rgba(226, 232, 240, 0.6);
+  --loading-content-shadow: 0 30px 110px rgba(148, 163, 184, 0.35);
+  --progress-indicator-sweep-color: rgba(255, 140, 105, 0.9);
+  --progress-indicator-base-color: rgba(255, 255, 255, 0.5);
+  --progress-indicator-surface-gradient: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.85), rgba(255, 244, 244, 0.65));
+  --progress-indicator-shadow: 0 20px 50px rgba(255, 173, 135, 0.35);
+  --progress-indicator-ring-background: radial-gradient(circle, rgba(255, 255, 255, 0.95), rgba(255, 244, 244, 0.7));
+  --progress-indicator-ring-shadow: inset 0 12px 24px rgba(148, 163, 184, 0.15);
+  --progress-indicator-inner-color: #fb7185;
+  --loading-text-color: #334155;
+  --loading-subtext-color: rgba(71, 85, 105, 0.85);
+  --progress-track-background: rgba(255, 255, 255, 0.7);
+  --progress-track-shadow: inset 0 4px 12px rgba(148, 163, 184, 0.4);
+  --progress-bar-background: linear-gradient(90deg, rgba(255, 183, 142, 0.95), rgba(255, 105, 180, 0.9));
+  --progress-bar-shadow: 0 6px 14px rgba(236, 72, 153, 0.25);
+  --progress-note-color: rgba(71, 85, 105, 0.75);
+  --progress-footnote-color: rgba(100, 116, 139, 0.7);
+  --loaded-state-background:
+    radial-gradient(circle at 20% 20%, rgba(255, 237, 213, 0.65), transparent 72%),
+    radial-gradient(circle at 78% 78%, rgba(224, 242, 254, 0.6), transparent 70%),
+    #f8fafc;
+  --loaded-message-background: rgba(255, 255, 255, 0.78);
+  --loaded-message-color: #1f2937;
+  --loaded-message-shadow: 0 30px 110px rgba(148, 163, 184, 0.35);
+  --loaded-message-heading-color: #334155;
+  --loaded-message-body-color: rgba(71, 85, 105, 0.78);
+  --wasted-duration-background: rgba(255, 105, 180, 0.12);
+  --wasted-duration-color: #be123c;
+  --quote-banner-background: rgba(15, 23, 42, 0.78);
+  --quote-banner-color: #f8fafc;
+  --quote-banner-shadow: 0 18px 48px rgba(15, 23, 42, 0.28);
+  --quote-banner-author-color: #fde68a;
   position: relative;
   min-height: 100vh;
   font-family: 'Rubik', 'Vazirmatn', 'IRANSans', 'Tahoma', sans-serif;
-  color: #1f2937;
-  background-color: #f8fafc;
+  color: var(--app-text-color);
+  background-color: var(--app-background-color);
   overflow: hidden;
+  color-scheme: var(--color-scheme);
 }
 
-.App--dark {
-  color: #e2e8f0;
-  background-color: #020617;
+.App.App--dark {
+  --color-scheme: dark;
+  --app-text-color: #e2e8f0;
+  --app-background-color: #020617;
+  --theme-toggle-border: rgba(148, 163, 184, 0.32);
+  --theme-toggle-background: rgba(71, 85, 105, 0.45);
+  --theme-toggle-color: #fcd34d;
+  --theme-toggle-shadow: 0 18px 34px rgba(2, 6, 23, 0.45);
+  --theme-toggle-hover-shadow: 0 24px 40px rgba(2, 6, 23, 0.55);
+  --loading-container-background:
+    radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(14, 116, 144, 0.45), transparent 76%),
+    radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(79, 70, 229, 0.45), transparent 74%),
+    radial-gradient(35% 35% at var(--g3x) var(--g3y), rgba(30, 64, 175, 0.4), transparent 72%),
+    radial-gradient(45% 45% at var(--g4x) var(--g4y), rgba(109, 40, 217, 0.35), transparent 74%),
+    radial-gradient(32% 32% at var(--g5x) var(--g5y), rgba(15, 118, 110, 0.38), transparent 72%),
+    radial-gradient(28% 28% at var(--g6x) var(--g6y), rgba(59, 130, 246, 0.35), transparent 74%),
+    radial-gradient(40% 40% at var(--g7x) var(--g7y), rgba(67, 56, 202, 0.3), transparent 72%),
+    radial-gradient(34% 34% at var(--g8x) var(--g8y), rgba(2, 132, 199, 0.32), transparent 72%),
+    radial-gradient(60% 60% at 50% 50%, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.94));
+  --loading-container-overlay:
+    radial-gradient(720px circle at 20% 18%, rgba(14, 165, 233, 0.32), transparent 74%),
+    radial-gradient(840px circle at 78% 72%, rgba(147, 51, 234, 0.28), transparent 74%),
+    radial-gradient(680px circle at 52% 40%, rgba(30, 64, 175, 0.28), transparent 74%),
+    radial-gradient(560px circle at 30% 80%, rgba(20, 83, 45, 0.24), transparent 77%);
+  --loading-container-overlay-blur: 58px;
+  --loading-container-overlay-opacity: 0.85;
+  --loading-content-background: linear-gradient(135deg, rgba(15, 23, 42, 0.86), rgba(30, 41, 59, 0.88));
+  --loading-content-border-color: rgba(51, 65, 85, 0.65);
+  --loading-content-shadow: 0 36px 110px rgba(2, 6, 23, 0.6);
+  --progress-indicator-sweep-color: rgba(56, 189, 248, 0.88);
+  --progress-indicator-base-color: rgba(15, 23, 42, 0.65);
+  --progress-indicator-surface-gradient: radial-gradient(circle at 50% 50%, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.82));
+  --progress-indicator-shadow: 0 20px 50px rgba(14, 165, 233, 0.25);
+  --progress-indicator-ring-background: radial-gradient(circle, rgba(30, 41, 59, 0.92), rgba(2, 6, 23, 0.88));
+  --progress-indicator-ring-shadow: inset 0 10px 22px rgba(8, 47, 73, 0.45);
+  --progress-indicator-inner-color: #facc15;
+  --loading-text-color: #e2e8f0;
+  --loading-subtext-color: rgba(226, 232, 240, 0.75);
+  --progress-track-background: rgba(15, 23, 42, 0.86);
+  --progress-track-shadow: inset 0 4px 12px rgba(15, 118, 110, 0.35);
+  --progress-bar-background: linear-gradient(90deg, rgba(56, 189, 248, 0.88), rgba(129, 140, 248, 0.9));
+  --progress-bar-shadow: 0 6px 14px rgba(59, 130, 246, 0.3);
+  --progress-note-color: rgba(203, 213, 225, 0.78);
+  --progress-footnote-color: rgba(148, 163, 184, 0.78);
+  --loaded-state-background:
+    radial-gradient(circle at 20% 20%, rgba(30, 64, 175, 0.32), transparent 72%),
+    radial-gradient(circle at 78% 78%, rgba(45, 212, 191, 0.26), transparent 70%),
+    #020617;
+  --loaded-message-background: rgba(15, 23, 42, 0.82);
+  --loaded-message-color: #e2e8f0;
+  --loaded-message-shadow: 0 30px 110px rgba(2, 6, 23, 0.65);
+  --loaded-message-heading-color: #f8fafc;
+  --loaded-message-body-color: rgba(226, 232, 240, 0.78);
+  --wasted-duration-background: rgba(56, 189, 248, 0.18);
+  --wasted-duration-color: #38bdf8;
+  --quote-banner-background: rgba(30, 41, 59, 0.85);
+  --quote-banner-color: #e2e8f0;
+  --quote-banner-shadow: 0 18px 48px rgba(2, 6, 23, 0.5);
+  --quote-banner-author-color: #38bdf8;
 }
 
 .theme-toggle {
@@ -120,10 +235,10 @@
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 50%;
-  border: 1px solid rgba(15, 23, 42, 0.1);
-  background: rgba(15, 23, 42, 0.72);
-  color: #f8fafc;
-  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.22);
+  border: 1px solid var(--theme-toggle-border);
+  background: var(--theme-toggle-background);
+  color: var(--theme-toggle-color);
+  box-shadow: var(--theme-toggle-shadow);
   backdrop-filter: blur(12px) saturate(150%);
   cursor: pointer;
   z-index: 5;
@@ -132,7 +247,7 @@
 
 .theme-toggle:hover {
   transform: translateY(-2px);
-  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.28);
+  box-shadow: var(--theme-toggle-hover-shadow);
 }
 
 .theme-toggle:focus-visible {
@@ -143,17 +258,6 @@
 .theme-toggle__icon {
   font-size: 1.4rem;
   line-height: 1;
-}
-
-.App--dark .theme-toggle {
-  border-color: rgba(148, 163, 184, 0.32);
-  background: rgba(71, 85, 105, 0.45);
-  color: #fcd34d;
-  box-shadow: 0 18px 34px rgba(2, 6, 23, 0.45);
-}
-
-.App--dark .theme-toggle:hover {
-  box-shadow: 0 24px 40px rgba(2, 6, 23, 0.55);
 }
 
 .visually-hidden {
@@ -206,30 +310,7 @@
   justify-content: center;
   min-height: 100vh;
   overflow: hidden;
-  background:
-    radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(255, 221, 244, 0.96), transparent 76%),
-    radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(255, 244, 214, 0.98), transparent 74%),
-    radial-gradient(35% 35% at var(--g3x) var(--g3y), rgba(214, 237, 255, 0.95), transparent 72%),
-    radial-gradient(45% 45% at var(--g4x) var(--g4y), rgba(255, 231, 218, 0.95), transparent 74%),
-    radial-gradient(32% 32% at var(--g5x) var(--g5y), rgba(230, 255, 242, 0.97), transparent 72%),
-    radial-gradient(28% 28% at var(--g6x) var(--g6y), rgba(255, 230, 240, 0.94), transparent 74%),
-    radial-gradient(40% 40% at var(--g7x) var(--g7y), rgba(222, 241, 255, 0.9), transparent 72%),
-    radial-gradient(34% 34% at var(--g8x) var(--g8y), rgba(255, 248, 224, 0.92), transparent 72%),
-    radial-gradient(60% 60% at 50% 50%, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.95));
-  animation: gradientFlow 22s ease-in-out infinite alternate;
-}
-
-.App--dark .loading-container {
-  background:
-    radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(14, 116, 144, 0.45), transparent 76%),
-    radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(79, 70, 229, 0.45), transparent 74%),
-    radial-gradient(35% 35% at var(--g3x) var(--g3y), rgba(30, 64, 175, 0.4), transparent 72%),
-    radial-gradient(45% 45% at var(--g4x) var(--g4y), rgba(109, 40, 217, 0.35), transparent 74%),
-    radial-gradient(32% 32% at var(--g5x) var(--g5y), rgba(15, 118, 110, 0.38), transparent 72%),
-    radial-gradient(28% 28% at var(--g6x) var(--g6y), rgba(59, 130, 246, 0.35), transparent 74%),
-    radial-gradient(40% 40% at var(--g7x) var(--g7y), rgba(67, 56, 202, 0.3), transparent 72%),
-    radial-gradient(34% 34% at var(--g8x) var(--g8y), rgba(2, 132, 199, 0.32), transparent 72%),
-    radial-gradient(60% 60% at 50% 50%, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.94));
+  background: var(--loading-container-background);
   animation: gradientFlow 22s ease-in-out infinite alternate;
 }
 
@@ -237,25 +318,11 @@
   content: '';
   position: absolute;
   inset: -18%;
-  background:
-    radial-gradient(720px circle at 20% 18%, rgba(255, 210, 234, 0.88), transparent 74%),
-    radial-gradient(840px circle at 78% 72%, rgba(255, 239, 207, 0.82), transparent 74%),
-    radial-gradient(680px circle at 52% 40%, rgba(209, 231, 255, 0.84), transparent 74%),
-    radial-gradient(560px circle at 30% 80%, rgba(213, 255, 235, 0.8), transparent 77%);
-  filter: blur(48px);
-  opacity: 0.98;
+  background: var(--loading-container-overlay);
+  filter: blur(var(--loading-container-overlay-blur));
+  opacity: var(--loading-container-overlay-opacity);
   animation: auroraDrift 26s ease-in-out infinite alternate;
   z-index: 0;
-}
-
-.App--dark .loading-container::before {
-  background:
-    radial-gradient(720px circle at 20% 18%, rgba(14, 165, 233, 0.32), transparent 74%),
-    radial-gradient(840px circle at 78% 72%, rgba(147, 51, 234, 0.28), transparent 74%),
-    radial-gradient(680px circle at 52% 40%, rgba(30, 64, 175, 0.28), transparent 74%),
-    radial-gradient(560px circle at 30% 80%, rgba(20, 83, 45, 0.24), transparent 77%);
-  filter: blur(58px);
-  opacity: 0.85;
 }
 
 .loading-content {
@@ -264,46 +331,26 @@
   text-align: center;
   padding: clamp(2.5rem, 6vw, 4rem);
   backdrop-filter: blur(22px) saturate(160%);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.86), rgba(255, 244, 244, 0.8));
+  background: var(--loading-content-background);
   border-radius: 36px;
-  box-shadow: 0 30px 110px rgba(148, 163, 184, 0.35);
-  border: 1px solid rgba(226, 232, 240, 0.6);
+  box-shadow: var(--loading-content-shadow);
+  border: 1px solid var(--loading-content-border-color);
   direction: rtl;
   animation: softFade 900ms ease both;
 }
 
-.App--dark .loading-content {
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.86), rgba(30, 41, 59, 0.88));
-  border: 1px solid rgba(51, 65, 85, 0.65);
-  box-shadow: 0 36px 110px rgba(2, 6, 23, 0.6);
-}
-
 .progress-indicator {
-  --progress: 0;
   position: relative;
   width: clamp(120px, 14vw, 170px);
   height: clamp(120px, 14vw, 170px);
   margin: 0 auto clamp(1.8rem, 4vw, 2.4rem);
   border-radius: 50%;
-  background: conic-gradient(
-      rgba(255, 140, 105, 0.9) calc(var(--progress) * 1%),
-      rgba(255, 255, 255, 0.5) calc(var(--progress) * 1%)
-    ),
-    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.85), rgba(255, 244, 244, 0.65));
+  background: var(--progress-indicator-surface-gradient);
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 20px 50px rgba(255, 173, 135, 0.35);
+  box-shadow: var(--progress-indicator-shadow);
   transition: background 220ms ease-out;
-}
-
-.App--dark .progress-indicator {
-  background: conic-gradient(
-      rgba(56, 189, 248, 0.88) calc(var(--progress) * 1%),
-      rgba(15, 23, 42, 0.65) calc(var(--progress) * 1%)
-    ),
-    radial-gradient(circle at 50% 50%, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.82));
-  box-shadow: 0 20px 50px rgba(14, 165, 233, 0.25);
 }
 
 .progress-indicator::after {
@@ -311,13 +358,8 @@
   position: absolute;
   inset: 10%;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.95), rgba(255, 244, 244, 0.7));
-  box-shadow: inset 0 12px 24px rgba(148, 163, 184, 0.15);
-}
-
-.App--dark .progress-indicator::after {
-  background: radial-gradient(circle, rgba(30, 41, 59, 0.92), rgba(2, 6, 23, 0.88));
-  box-shadow: inset 0 10px 22px rgba(8, 47, 73, 0.45);
+  background: var(--progress-indicator-ring-background);
+  box-shadow: var(--progress-indicator-ring-shadow);
 }
 
 .progress-indicator__inner {
@@ -327,12 +369,8 @@
   align-items: flex-end;
   justify-content: center;
   gap: 0.35rem;
-  color: #fb7185;
+  color: var(--progress-indicator-inner-color);
   font-weight: 700;
-}
-
-.App--dark .progress-indicator__inner {
-  color: #facc15;
 }
 
 .progress-indicator__value {
@@ -350,21 +388,13 @@
   font-weight: 700;
   letter-spacing: 0.03em;
   margin: 0 0 1rem;
-  color: #334155;
-}
-
-.App--dark .loading-text {
-  color: #e2e8f0;
+  color: var(--loading-text-color);
 }
 
 .loading-subtext {
   font-size: clamp(1.15rem, 2.3vw, 1.6rem);
   margin: 0 0 1.5rem;
-  color: rgba(71, 85, 105, 0.85);
-}
-
-.App--dark .loading-subtext {
-  color: rgba(226, 232, 240, 0.75);
+  color: var(--loading-subtext-color);
 }
 
 .progress-track {
@@ -372,47 +402,29 @@
   height: 14px;
   margin: 0 auto 1rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.7);
-  box-shadow: inset 0 4px 12px rgba(148, 163, 184, 0.4);
+  background: var(--progress-track-background);
+  box-shadow: var(--progress-track-shadow);
   overflow: hidden;
-}
-
-.App--dark .progress-track {
-  background: rgba(15, 23, 42, 0.86);
-  box-shadow: inset 0 4px 12px rgba(15, 118, 110, 0.35);
 }
 
 .progress-bar {
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, rgba(255, 183, 142, 0.95), rgba(255, 105, 180, 0.9));
-  box-shadow: 0 6px 14px rgba(236, 72, 153, 0.25);
+  background: var(--progress-bar-background);
+  box-shadow: var(--progress-bar-shadow);
   transition: width 320ms cubic-bezier(0.33, 1, 0.68, 1);
-}
-
-.App--dark .progress-bar {
-  background: linear-gradient(90deg, rgba(56, 189, 248, 0.88), rgba(129, 140, 248, 0.9));
-  box-shadow: 0 6px 14px rgba(59, 130, 246, 0.3);
 }
 
 .progress-note {
   margin: 0 0 0.5rem;
   font-size: clamp(0.98rem, 2.1vw, 1.24rem);
-  color: rgba(71, 85, 105, 0.75);
-}
-
-.App--dark .progress-note {
-  color: rgba(203, 213, 225, 0.78);
+  color: var(--progress-note-color);
 }
 
 .progress-footnote {
   margin: 0;
   font-size: clamp(0.85rem, 1.8vw, 1.08rem);
-  color: rgba(100, 116, 139, 0.7);
-}
-
-.App--dark .progress-footnote {
-  color: rgba(148, 163, 184, 0.78);
+  color: var(--progress-footnote-color);
 }
 
 .loaded-state {
@@ -423,17 +435,7 @@
   justify-content: center;
   padding: 2rem;
   overflow: hidden;
-  background:
-    radial-gradient(circle at 20% 20%, rgba(255, 237, 213, 0.65), transparent 72%),
-    radial-gradient(circle at 78% 78%, rgba(224, 242, 254, 0.6), transparent 70%),
-    #f8fafc;
-}
-
-.App--dark .loaded-state {
-  background:
-    radial-gradient(circle at 20% 20%, rgba(30, 64, 175, 0.32), transparent 72%),
-    radial-gradient(circle at 78% 78%, rgba(45, 212, 191, 0.26), transparent 70%),
-    #020617;
+  background: var(--loaded-state-background);
 }
 
 .confetti-layer {
@@ -451,41 +453,27 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  color: #1f2937;
+  color: var(--loaded-message-color);
   padding: 2rem;
   gap: 1rem;
-  background: rgba(255, 255, 255, 0.78);
+  background: var(--loaded-message-background);
   border-radius: 32px;
-  box-shadow: 0 30px 110px rgba(148, 163, 184, 0.35);
+  box-shadow: var(--loaded-message-shadow);
   backdrop-filter: blur(14px) saturate(140%);
   animation: softFade 900ms ease both;
-}
-
-.App--dark .loaded-message {
-  background: rgba(15, 23, 42, 0.82);
-  color: #e2e8f0;
-  box-shadow: 0 30px 110px rgba(2, 6, 23, 0.65);
 }
 
 .loaded-message h1 {
   font-size: clamp(2.4rem, 5vw, 3.5rem);
   margin: 0;
-  color: #334155;
-}
-
-.App--dark .loaded-message h1 {
-  color: #f8fafc;
+  color: var(--loaded-message-heading-color);
 }
 
 .loaded-message bdi {
   margin: 0;
   font-size: clamp(1.1rem, 2.2vw, 1.6rem);
-  color: rgba(71, 85, 105, 0.78);
+  color: var(--loaded-message-body-color);
   max-width: min(620px, 90vw);
-}
-
-.App--dark .loaded-message bdi {
-  color: rgba(226, 232, 240, 0.78);
 }
 
 .wasted-duration {
@@ -493,14 +481,9 @@
   padding: 0.25rem 0.6rem;
   margin-inline: 0.15rem;
   border-radius: 999px;
-  background: rgba(255, 105, 180, 0.12);
-  color: #be123c !important;
+  background: var(--wasted-duration-background);
+  color: var(--wasted-duration-color) !important;
   font-weight: 600;
-}
-
-.App--dark .wasted-duration {
-  background: rgba(56, 189, 248, 0.18);
-  color: #38bdf8 !important;
 }
 
 .quote-banner {
@@ -510,19 +493,13 @@
   transform: translate(-50%, 28px);
   padding: 0.75rem 1.8rem;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.78);
-  color: #f8fafc;
-  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.28);
+  background: var(--quote-banner-background);
+  color: var(--quote-banner-color);
+  box-shadow: var(--quote-banner-shadow);
   pointer-events: none;
   opacity: 0;
   transition: opacity 900ms ease, transform 900ms ease;
   backdrop-filter: blur(14px) saturate(160%);
-}
-
-.App--dark .quote-banner {
-  background: rgba(30, 41, 59, 0.85);
-  color: #e2e8f0;
-  box-shadow: 0 18px 48px rgba(2, 6, 23, 0.5);
 }
 
 .quote-banner--visible {
@@ -552,11 +529,7 @@
 
 .quote-banner__author {
   font-weight: 600;
-  color: #fde68a;
-}
-
-.App--dark .quote-banner__author {
-  color: #38bdf8;
+  color: var(--quote-banner-author-color);
 }
 
 @keyframes gradientFlow {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,14 +51,21 @@ function App() {
 
     const storedPreference = window.localStorage.getItem('theme');
     if (storedPreference === 'dark') {
+      document.documentElement.dataset.theme = 'dark';
+      document.documentElement.style.colorScheme = 'dark';
       return true;
     }
     if (storedPreference === 'light') {
+      document.documentElement.dataset.theme = 'light';
+      document.documentElement.style.colorScheme = 'light';
       return false;
     }
 
     const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)');
-    return prefersDark ? prefersDark.matches : false;
+    const isDark = prefersDark ? prefersDark.matches : false;
+    document.documentElement.dataset.theme = isDark ? 'dark' : 'light';
+    document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+    return isDark;
   });
   const [isLoading, setIsLoading] = useState(true);
   const [progress, setProgress] = useState(0);
@@ -81,11 +88,53 @@ function App() {
       return;
     }
 
-    window.localStorage.setItem('theme', isDarkMode ? 'dark' : 'light');
+    const nextTheme = isDarkMode ? 'dark' : 'light';
+    window.localStorage.setItem('theme', nextTheme);
+    document.documentElement.dataset.theme = nextTheme;
+    document.documentElement.style.colorScheme = nextTheme;
   }, [isDarkMode]);
 
+  const themeToggleRef = useRef<HTMLButtonElement | null>(null);
+
   const toggleTheme = useCallback(() => {
-    setIsDarkMode((prev) => !prev);
+    if (typeof document === 'undefined') {
+      setIsDarkMode((prev) => !prev);
+      return;
+    }
+
+    const button = themeToggleRef.current;
+    const rect = button?.getBoundingClientRect();
+    const x = rect ? rect.left + rect.width / 2 : window.innerWidth / 2;
+    const y = rect ? rect.top + rect.height / 2 : window.innerHeight / 2;
+
+    const applyTheme = () => {
+      setIsDarkMode((prev) => !prev);
+    };
+
+    if ((document as any).startViewTransition) {
+      const transition = (document as any).startViewTransition(applyTheme);
+      transition?.ready?.then(() => {
+        const maxHorizontal = Math.max(x, window.innerWidth - x);
+        const maxVertical = Math.max(y, window.innerHeight - y);
+        const maxRadius = Math.hypot(maxHorizontal, maxVertical);
+        document.documentElement.animate(
+          {
+            clipPath: [
+              `circle(0px at ${x}px ${y}px)`,
+              `circle(${maxRadius}px at ${x}px ${y}px)`,
+            ],
+          },
+          {
+            duration: 1000,
+            easing: 'ease-in-out',
+            pseudoElement: '::view-transition-new(root)',
+          }
+        );
+      });
+      return;
+    }
+
+    applyTheme();
   }, []);
 
   const flushProgressUpdate = useCallback(() => {
@@ -308,9 +357,13 @@ function App() {
   }, [isLoading]);
 
   const progressValue = Math.min(100, Math.round(progress));
-  const progressIndicatorStyle = {
-    '--progress': Math.min(progress, 100).toFixed(2),
-  } as React.CSSProperties;
+  const progressIndicatorStyle = React.useMemo<React.CSSProperties>(() => {
+    const clampedProgress = Math.max(0, Math.min(progress, 100));
+    const stop = clampedProgress.toFixed(2);
+    return {
+      background: `conic-gradient(var(--progress-indicator-sweep-color) ${stop}%, var(--progress-indicator-base-color) ${stop}%), var(--progress-indicator-surface-gradient)`,
+    };
+  }, [progress]);
   const activeQuote = isLoading ? TIME_QUOTES[currentQuoteIndex] : undefined;
   // const elapsedForDisplay = isLoading ? liveElapsedMs : elapsedMs ?? loadingDurationMs;
   // const formattedElapsed = React.useMemo(() => {
@@ -326,6 +379,7 @@ function App() {
     <div className={`App${isDarkMode ? ' App--dark' : ''}`}>
       <button
         type="button"
+        ref={themeToggleRef}
         className="theme-toggle"
         onClick={toggleTheme}
         aria-label={isDarkMode ? 'تغییر به حالت روشن' : 'تغییر به حالت تیره'}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,13 @@
 :root {
+  color-scheme: light;
+  --page-background-color: #f8fafc;
+  --page-text-color: #1f2937;
+}
+
+:root[data-theme='dark'] {
   color-scheme: dark;
-  background-color: #020617;
+  --page-background-color: #020617;
+  --page-text-color: #f8fafc;
 }
 
 html,
@@ -14,8 +21,8 @@ body {
   font-family: 'Rubik', 'Vazirmatn', 'IRANSans', 'Tahoma', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #020617;
-  color: #f8fafc;
+  background-color: var(--page-background-color);
+  color: var(--page-text-color);
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- refactor theme styles to rely on CSS custom properties for light and dark palettes
- drive theme toggling through a view-transition clip animation centered on the switch
- render the progress indicator background directly from React without relying on CSS progress vars

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ed7f5dbc1c832797ea71dfb7921750