### PR TITLE
Add selectable theme transition styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -105,6 +105,20 @@
   --theme-toggle-color: #f8fafc;
   --theme-toggle-shadow: 0 18px 30px rgba(15, 23, 42, 0.22);
   --theme-toggle-hover-shadow: 0 20px 38px rgba(15, 23, 42, 0.28);
+  --transition-panel-background: rgba(255, 255, 255, 0.82);
+  --transition-panel-border: rgba(148, 163, 184, 0.35);
+  --transition-panel-shadow: 0 20px 45px rgba(148, 163, 184, 0.32);
+  --transition-panel-label-color: rgba(15, 23, 42, 0.7);
+  --transition-option-background: rgba(255, 255, 255, 0.66);
+  --transition-option-border: rgba(148, 163, 184, 0.36);
+  --transition-option-hover-border: rgba(59, 130, 246, 0.45);
+  --transition-option-active-border: rgba(236, 72, 153, 0.58);
+  --transition-option-active-background: rgba(236, 72, 153, 0.14);
+  --transition-option-text-color: #1f2937;
+  --transition-option-description-color: rgba(71, 85, 105, 0.78);
+  --transition-option-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  --transition-option-hover-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
+  --transition-option-active-shadow: 0 16px 38px rgba(236, 72, 153, 0.22);
   --loading-container-background:
     radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(255, 221, 244, 0.96), transparent 76%),
     radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(255, 244, 214, 0.98), transparent 74%),
@@ -164,6 +178,20 @@
   --theme-toggle-color: #fcd34d;
   --theme-toggle-shadow: 0 18px 34px rgba(2, 6, 23, 0.45);
   --theme-toggle-hover-shadow: 0 24px 40px rgba(2, 6, 23, 0.55);
+  --transition-panel-background: rgba(15, 23, 42, 0.8);
+  --transition-panel-border: rgba(51, 65, 85, 0.68);
+  --transition-panel-shadow: 0 24px 50px rgba(2, 6, 23, 0.65);
+  --transition-panel-label-color: rgba(226, 232, 240, 0.85);
+  --transition-option-background: rgba(15, 23, 42, 0.64);
+  --transition-option-border: rgba(51, 65, 85, 0.7);
+  --transition-option-hover-border: rgba(56, 189, 248, 0.55);
+  --transition-option-active-border: rgba(129, 140, 248, 0.6);
+  --transition-option-active-background: rgba(56, 189, 248, 0.12);
+  --transition-option-text-color: #e2e8f0;
+  --transition-option-description-color: rgba(203, 213, 225, 0.76);
+  --transition-option-shadow: 0 12px 32px rgba(2, 6, 23, 0.45);
+  --transition-option-hover-shadow: 0 20px 46px rgba(2, 6, 23, 0.55);
+  --transition-option-active-shadow: 0 18px 40px rgba(56, 189, 248, 0.28);
   --loading-container-background:
     radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(14, 116, 144, 0.45), transparent 76%),
     radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(79, 70, 229, 0.45), transparent 74%),
@@ -227,6 +255,116 @@
   color: var(--app-text-color);
   background-color: var(--app-background-color);
   overflow: hidden;
+}
+
+.transition-panel {
+  position: fixed;
+  top: clamp(1rem, 4vw, 2.5rem);
+  right: clamp(1rem, 4vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.2rem;
+  border-radius: 26px;
+  background: var(--transition-panel-background);
+  border: 1px solid var(--transition-panel-border);
+  box-shadow: var(--transition-panel-shadow);
+  backdrop-filter: blur(16px) saturate(160%);
+  z-index: 6;
+  width: min(20rem, calc(100vw - 2rem));
+  direction: rtl;
+}
+
+.transition-panel__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  color: var(--transition-panel-label-color);
+}
+
+.transition-panel__options {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.transition-option {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 18px;
+  border: 1px solid var(--transition-option-border);
+  background: var(--transition-option-background);
+  cursor: pointer;
+  transition: border-color 180ms ease, background 200ms ease, box-shadow 200ms ease;
+  box-shadow: var(--transition-option-shadow);
+}
+
+.transition-option:hover {
+  border-color: var(--transition-option-hover-border);
+  box-shadow: var(--transition-option-hover-shadow);
+}
+
+.transition-option:focus-within {
+  outline: 2px solid rgba(56, 189, 248, 0.65);
+  outline-offset: 3px;
+}
+
+.transition-option--active {
+  border-color: var(--transition-option-active-border);
+  background: var(--transition-option-active-background);
+  box-shadow: var(--transition-option-active-shadow);
+}
+
+.transition-option__input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.transition-option__icon {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.transition-option__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--transition-option-text-color);
+}
+
+.transition-option__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.transition-option__description {
+  font-size: 0.78rem;
+  color: var(--transition-option-description-color);
+  line-height: 1.4;
+}
+
+@media (max-width: 720px) {
+  .transition-panel {
+    top: auto;
+    bottom: clamp(1rem, 4vw, 2.2rem);
+    right: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(22rem, calc(100vw - 2.2rem));
+    gap: 0.6rem;
+  }
+
+  .transition-panel__options {
+    grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+  }
 }
 
 .theme-toggle {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,44 @@ const PERSIAN_DIGITS = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '�
 const QUOTE_DISPLAY_DURATION_MS = 10_000;
 const QUOTE_FADE_DURATION_MS = 1_000;
 
+type ThemeTransitionStyle = 'fade' | 'wipe' | 'slide' | 'tilt';
+
+type ThemeTransitionOption = {
+  value: ThemeTransitionStyle;
+  label: string;
+  description: string;
+  icon: string;
+};
+
+const THEME_TRANSITION_STORAGE_KEY = 'theme-transition-style';
+
+const THEME_TRANSITION_OPTIONS: readonly ThemeTransitionOption[] = [
+  {
+    value: 'fade',
+    label: 'محو آرام',
+    description: 'تعویض نرم با محو تدریجی صحنه‌ها',
+    icon: '🌫️',
+  },
+  {
+    value: 'wipe',
+    label: 'پرده‌ای',
+    description: 'پرده‌ای که از نقطهٔ کلیک باز یا بسته می‌شود',
+    icon: '🪟',
+  },
+  {
+    value: 'slide',
+    label: 'سر خوردن',
+    description: 'جا‌به‌جایی عمودی با حس کشویی نرم',
+    icon: '🎞️',
+  },
+  {
+    value: 'tilt',
+    label: 'چرخش سه‌بعدی',
+    description: 'چرخش منشوری برای تعویض سریع تم',
+    icon: '🪩',
+  },
+];
+
 const shuffleArray = <T,>(items: readonly T[]) => {
   const cloned = [...items];
   for (let i = cloned.length - 1; i > 0; i -= 1) {
@@ -97,6 +135,20 @@ function App() {
   const quoteIntervalRef = useRef<number | null>(null);
   const quoteFadeTimeoutRef = useRef<number | null>(null);
 
+  const [transitionStyle, setTransitionStyle] = useState<ThemeTransitionStyle>(() => {
+    if (typeof window === 'undefined') {
+      return 'fade';
+    }
+
+    const stored = window.localStorage.getItem(
+      THEME_TRANSITION_STORAGE_KEY
+    ) as ThemeTransitionStyle | null;
+
+    return stored && THEME_TRANSITION_OPTIONS.some((option) => option.value === stored)
+      ? stored
+      : 'fade';
+  });
+
   useEffect(() => {
     if (typeof window === 'undefined') {
       return;
@@ -106,6 +158,14 @@ function App() {
   }, [isDarkMode]);
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(THEME_TRANSITION_STORAGE_KEY, transitionStyle);
+  }, [transitionStyle]);
+
+  useEffect(() => {
     if (typeof document === 'undefined') {
       return;
     }
@@ -113,17 +173,30 @@ function App() {
     document.documentElement.dataset.theme = isDarkMode ? 'dark' : 'light';
   }, [isDarkMode]);
 
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    document.documentElement.dataset.themeTransition = transitionStyle;
+  }, [transitionStyle]);
+
   const toggleTheme = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      if (typeof document === 'undefined') {
+      if (typeof document === 'undefined' || typeof window === 'undefined') {
         setIsDarkMode((prev) => !prev);
         return;
       }
 
-      const target = event.currentTarget;
-      const rect = target.getBoundingClientRect();
-      const x = rect.left + rect.width / 2;
-      const y = rect.top + rect.height / 2;
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const isKeyboardTrigger = event.clientX === 0 && event.clientY === 0;
+      const pointerX = isKeyboardTrigger ? viewportWidth / 2 : event.clientX;
+      const pointerY = isKeyboardTrigger ? viewportHeight / 2 : event.clientY;
+      const relativeX = viewportWidth ? pointerX / viewportWidth : 0.5;
+      const relativeY = viewportHeight ? pointerY / viewportHeight : 0.5;
+      const horizontalBias = relativeX < 0.5 ? 'left' : 'right';
+      const verticalBias = relativeY < 0.5 ? 'top' : 'bottom';
 
       const updateTheme = () => {
         flushSync(() => {
@@ -142,21 +215,124 @@ function App() {
         transition.ready
           .then(() => {
             const root = document.documentElement;
-            const maxRadius = Math.hypot(
-              Math.max(x, window.innerWidth - x),
-              Math.max(y, window.innerHeight - y)
-            );
+            const sharedTiming: KeyframeAnimationOptions = {
+              duration: 620,
+              easing: 'cubic-bezier(0.33, 1, 0.68, 1)',
+              fill: 'both',
+            };
+
+            if (transitionStyle === 'fade') {
+              root.animate(
+                [
+                  { opacity: 1 },
+                  { opacity: 0 },
+                ],
+                {
+                  ...sharedTiming,
+                  pseudoElement: '::view-transition-old(root)',
+                }
+              );
+              root.animate(
+                [
+                  { opacity: 0 },
+                  { opacity: 1 },
+                ],
+                {
+                  ...sharedTiming,
+                  pseudoElement: '::view-transition-new(root)',
+                }
+              );
+              return;
+            }
+
+            if (transitionStyle === 'wipe') {
+              const fromLeft = horizontalBias === 'left';
+              const clipPathClosed = fromLeft
+                ? 'inset(0% 0% 0% 100%)'
+                : 'inset(0% 100% 0% 0%)';
+              const clipPathOpen = 'inset(0% 0% 0% 0%)';
+
+              root.animate(
+                [
+                  { clipPath: clipPathOpen, opacity: 1 },
+                  { clipPath: clipPathClosed, opacity: 0.2 },
+                ],
+                {
+                  ...sharedTiming,
+                  easing: 'cubic-bezier(0.4, 0, 1, 1)',
+                  pseudoElement: '::view-transition-old(root)',
+                }
+              );
+              root.animate(
+                [
+                  { clipPath: clipPathClosed, opacity: 0.15 },
+                  { clipPath: clipPathOpen, opacity: 1 },
+                ],
+                {
+                  ...sharedTiming,
+                  easing: 'cubic-bezier(0, 0, 0.2, 1)',
+                  pseudoElement: '::view-transition-new(root)',
+                }
+              );
+              return;
+            }
+
+            if (transitionStyle === 'slide') {
+              const fromTop = verticalBias === 'top';
+              const translateStart = fromTop ? '-16%' : '16%';
+              const translateOpposite = fromTop ? '16%' : '-16%';
+
+              root.animate(
+                [
+                  { transform: 'translateY(0%)', opacity: 1 },
+                  { transform: `translateY(${translateStart})`, opacity: 0 },
+                ],
+                {
+                  ...sharedTiming,
+                  easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+                  pseudoElement: '::view-transition-old(root)',
+                }
+              );
+              root.animate(
+                [
+                  { transform: `translateY(${translateOpposite})`, opacity: 0 },
+                  { transform: 'translateY(0%)', opacity: 1 },
+                ],
+                {
+                  ...sharedTiming,
+                  easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+                  pseudoElement: '::view-transition-new(root)',
+                }
+              );
+              return;
+            }
+
+            const rotateDirection = horizontalBias === 'left' ? -1 : 1;
+            const perspective = 'perspective(1200px)';
 
             root.animate(
+              [
+                { transform: `${perspective} rotateY(0deg)`, opacity: 1 },
+                { transform: `${perspective} rotateY(${rotateDirection * 22}deg)`, opacity: 0.6 },
+                { transform: `${perspective} rotateY(${rotateDirection * 90}deg)`, opacity: 0 },
+              ],
               {
-                clipPath: [
-                  `circle(0px at ${x}px ${y}px)`,
-                  `circle(${maxRadius}px at ${x}px ${y}px)`,
-                ],
-              },
+                ...sharedTiming,
+                duration: 680,
+                easing: 'cubic-bezier(0.76, 0, 0.24, 1)',
+                pseudoElement: '::view-transition-old(root)',
+              }
+            );
+            root.animate(
+              [
+                { transform: `${perspective} rotateY(${-rotateDirection * 90}deg)`, opacity: 0 },
+                { transform: `${perspective} rotateY(${-rotateDirection * 22}deg)`, opacity: 0.7 },
+                { transform: `${perspective} rotateY(0deg)`, opacity: 1 },
+              ],
               {
-                duration: 600,
-                easing: 'ease-in-out',
+                ...sharedTiming,
+                duration: 680,
+                easing: 'cubic-bezier(0.17, 0.84, 0.44, 1)',
                 pseudoElement: '::view-transition-new(root)',
               }
             );
@@ -168,7 +344,7 @@ function App() {
         updateTheme();
       }
     },
-    []
+    [transitionStyle]
   );
 
   const flushProgressUpdate = useCallback(() => {
@@ -422,6 +598,37 @@ function App() {
 
   return (
     <div className="App">
+      <div className="transition-panel" role="group" aria-labelledby="transition-panel-label">
+        <span id="transition-panel-label" className="transition-panel__label">
+          سبک تغییر تم
+        </span>
+        <div className="transition-panel__options">
+          {THEME_TRANSITION_OPTIONS.map((option) => (
+            <label
+              key={option.value}
+              className={`transition-option${
+                transitionStyle === option.value ? ' transition-option--active' : ''
+              }`}
+            >
+              <input
+                type="radio"
+                name="theme-transition"
+                value={option.value}
+                checked={transitionStyle === option.value}
+                onChange={() => setTransitionStyle(option.value)}
+                className="transition-option__input"
+              />
+              <span className="transition-option__icon" aria-hidden="true">
+                {option.icon}
+              </span>
+              <span className="transition-option__text">
+                <span className="transition-option__title">{option.label}</span>
+                <span className="transition-option__description">{option.description}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
       <button
         type="button"
         className="theme-toggle"


### PR DESCRIPTION
## Summary
- add a theme transition selector with four animation styles and persist the choice
- replace the circle clip-path view transition with fade, wipe, slide, and tilt animations
- style the new selector to match the app’s light and dark palettes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed91c2ea78832780ca51087b954b8e