### PR TITLE
Add selectable theme transition animations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -105,6 +105,13 @@
   --theme-toggle-color: #f8fafc;
   --theme-toggle-shadow: 0 18px 30px rgba(15, 23, 42, 0.22);
   --theme-toggle-hover-shadow: 0 20px 38px rgba(15, 23, 42, 0.28);
+  --theme-transition-background: rgba(255, 255, 255, 0.86);
+  --theme-transition-border: rgba(148, 163, 184, 0.35);
+  --theme-transition-text: rgba(30, 41, 59, 0.92);
+  --theme-transition-option-hover: rgba(15, 23, 42, 0.08);
+  --theme-transition-option-active: rgba(236, 72, 153, 0.12);
+  --theme-transition-option-active-border: rgba(236, 72, 153, 0.32);
+  --theme-transition-option-shadow: 0 12px 34px rgba(148, 163, 184, 0.25);
   --loading-container-background:
     radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(255, 221, 244, 0.96), transparent 76%),
     radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(255, 244, 214, 0.98), transparent 74%),
@@ -164,6 +171,13 @@
   --theme-toggle-color: #fcd34d;
   --theme-toggle-shadow: 0 18px 34px rgba(2, 6, 23, 0.45);
   --theme-toggle-hover-shadow: 0 24px 40px rgba(2, 6, 23, 0.55);
+  --theme-transition-background: rgba(15, 23, 42, 0.72);
+  --theme-transition-border: rgba(71, 85, 105, 0.6);
+  --theme-transition-text: rgba(226, 232, 240, 0.96);
+  --theme-transition-option-hover: rgba(148, 163, 184, 0.2);
+  --theme-transition-option-active: rgba(56, 189, 248, 0.2);
+  --theme-transition-option-active-border: rgba(56, 189, 248, 0.45);
+  --theme-transition-option-shadow: 0 14px 36px rgba(2, 6, 23, 0.6);
   --loading-container-background:
     radial-gradient(48% 48% at var(--g1x) var(--g1y), rgba(14, 116, 144, 0.45), transparent 76%),
     radial-gradient(38% 38% at var(--g2x) var(--g2y), rgba(79, 70, 229, 0.45), transparent 74%),
@@ -262,6 +276,80 @@
 .theme-toggle__icon {
   font-size: 1.4rem;
   line-height: 1;
+}
+
+.theme-transition-picker {
+  position: fixed;
+  top: calc(clamp(1rem, 3vw, 1.75rem) + 3.6rem);
+  left: clamp(1rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 18px;
+  border: 1px solid var(--theme-transition-border);
+  background: var(--theme-transition-background);
+  color: var(--theme-transition-text);
+  box-shadow: var(--theme-transition-option-shadow);
+  backdrop-filter: blur(14px) saturate(150%);
+  z-index: 4;
+  min-width: clamp(11.5rem, 24vw, 15rem);
+  direction: rtl;
+  transform: none;
+}
+
+.theme-transition-picker__heading {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  opacity: 0.82;
+}
+
+.theme-transition-picker__options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.theme-transition-picker__option {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 200ms ease, border-color 200ms ease, transform 180ms ease;
+  font-size: 0.85rem;
+}
+
+.theme-transition-picker__option:hover {
+  background: var(--theme-transition-option-hover);
+  border-color: rgba(148, 163, 184, 0.2);
+  transform: translateY(-1px);
+}
+
+.theme-transition-picker__option:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.7);
+  outline-offset: 3px;
+}
+
+.theme-transition-picker__option--active {
+  background: var(--theme-transition-option-active);
+  border-color: var(--theme-transition-option-active-border);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+
+.theme-transition-picker__icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.theme-transition-picker__text {
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .visually-hidden {
@@ -534,6 +622,56 @@
 .quote-banner__author {
   font-weight: 600;
   color: var(--quote-banner-author-color);
+}
+
+@media (max-width: 768px) {
+  .theme-transition-picker {
+    min-width: clamp(10rem, 60vw, 15rem);
+  }
+}
+
+@media (max-width: 640px) {
+  .theme-transition-picker {
+    top: auto;
+    bottom: clamp(1rem, 5vw, 2.2rem);
+    left: 50%;
+    transform: translateX(-50%);
+    min-width: min(90vw, 20rem);
+  }
+
+  .theme-transition-picker__options {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .theme-transition-picker__option {
+    flex: 1 1 calc(50% - 0.4rem);
+    justify-content: center;
+  }
+
+  .theme-transition-picker__text {
+    font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .theme-transition-picker {
+    padding: 0.65rem 0.7rem;
+    gap: 0.4rem;
+  }
+
+  .theme-transition-picker__options {
+    gap: 0.3rem;
+  }
+
+  .theme-transition-picker__option {
+    padding: 0.5rem;
+  }
+
+  .theme-transition-picker__text {
+    display: none;
+  }
 }
 
 @keyframes gradientFlow {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import Confetti from 'react-confetti';
 import './App.css';
@@ -19,6 +19,183 @@ const MAX_LOADING_DURATION_MS = 240_000;
 const PERSIAN_DIGITS = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
 const QUOTE_DISPLAY_DURATION_MS = 10_000;
 const QUOTE_FADE_DURATION_MS = 1_000;
+
+type ThemeTransitionId = 'fade' | 'slide' | 'flip' | 'zoom';
+
+type ThemeTransitionContext = {
+  pointer: { x: number; y: number };
+  nextTheme: 'light' | 'dark';
+};
+
+type ThemeTransition = {
+  id: ThemeTransitionId;
+  label: string;
+  description: string;
+  icon: string;
+  apply: (root: Element, context: ThemeTransitionContext) => void;
+};
+
+const THEME_TRANSITIONS: readonly ThemeTransition[] = [
+  {
+    id: 'fade',
+    label: 'محو آرام',
+    description: 'تعویض ملایم با محوشدن نرم',
+    icon: '🌫️',
+    apply: (root) => {
+      const duration = 520;
+      root.animate(
+        [
+          { opacity: 0, filter: 'blur(16px)' },
+          { opacity: 1, filter: 'blur(0px)' },
+        ],
+        {
+          duration,
+          easing: 'cubic-bezier(0.33, 1, 0.68, 1)',
+          pseudoElement: '::view-transition-new(root)',
+        }
+      );
+      root.animate(
+        [
+          { opacity: 1, filter: 'blur(0px)' },
+          { opacity: 0, filter: 'blur(12px)' },
+        ],
+        {
+          duration: duration * 0.85,
+          easing: 'cubic-bezier(0.33, 1, 0.68, 1)',
+          pseudoElement: '::view-transition-old(root)',
+        }
+      );
+    },
+  },
+  {
+    id: 'slide',
+    label: 'سر خوردن',
+    description: 'ورود صحنه از سمتی که کلیک کردی',
+    icon: '🛝',
+    apply: (root, { pointer }) => {
+      const width = typeof window !== 'undefined' ? window.innerWidth : 0;
+      const fromLeft = width ? pointer.x < width / 2 : pointer.x < 0;
+      const entryOffset = fromLeft ? '-12%' : '12%';
+      const exitOffset = fromLeft ? '16%' : '-16%';
+      const duration = 640;
+      const easing = 'cubic-bezier(0.22, 1, 0.36, 1)';
+      root.animate(
+        [
+          { transform: `translateX(${entryOffset})`, opacity: 0.55 },
+          { transform: 'translateX(0%)', opacity: 1 },
+        ],
+        {
+          duration,
+          easing,
+          pseudoElement: '::view-transition-new(root)',
+        }
+      );
+      root.animate(
+        [
+          { transform: 'translateX(0%)', opacity: 1 },
+          { transform: `translateX(${exitOffset})`, opacity: 0.1 },
+        ],
+        {
+          duration,
+          easing,
+          pseudoElement: '::view-transition-old(root)',
+        }
+      );
+    },
+  },
+  {
+    id: 'flip',
+    label: 'چرخش سه‌بعدی',
+    description: 'چرخش کارت‌مانند بین دو تم',
+    icon: '🪞',
+    apply: (root, { nextTheme }) => {
+      const rotateIn = nextTheme === 'dark' ? '-82deg' : '82deg';
+      const rotateOut = nextTheme === 'dark' ? '72deg' : '-72deg';
+      const duration = 700;
+      const easing = 'cubic-bezier(0.4, 0, 0.2, 1)';
+      root.animate(
+        [
+          {
+            transform: `perspective(1400px) rotateY(${rotateIn}) scale(0.96)`,
+            opacity: 0.25,
+          },
+          { transform: 'perspective(1400px) rotateY(0deg) scale(1)', opacity: 1 },
+        ],
+        {
+          duration,
+          easing,
+          pseudoElement: '::view-transition-new(root)',
+        }
+      );
+      root.animate(
+        [
+          { transform: 'perspective(1400px) rotateY(0deg) scale(1)', opacity: 1 },
+          {
+            transform: `perspective(1400px) rotateY(${rotateOut}) scale(0.9)`,
+            opacity: 0,
+          },
+        ],
+        {
+          duration,
+          easing,
+          pseudoElement: '::view-transition-old(root)',
+        }
+      );
+    },
+  },
+  {
+    id: 'zoom',
+    label: 'زوم پویا',
+    description: 'بزرگ‌نمایی نقطه‌ی فوکوس کلیک',
+    icon: '🔍',
+    apply: (root, { pointer, nextTheme }) => {
+      const width = typeof window !== 'undefined' ? window.innerWidth : 1;
+      const height = typeof window !== 'undefined' ? window.innerHeight : 1;
+      const offsetX = (pointer.x / width - 0.5) * 8;
+      const offsetY = (pointer.y / height - 0.5) * 8;
+      const zoomTarget = nextTheme === 'dark' ? 1.08 : 1.12;
+      const duration = 560;
+      const easing = 'cubic-bezier(0.33, 1, 0.68, 1)';
+      root.animate(
+        [
+          {
+            transform: `translate(${offsetX}%, ${offsetY}%) scale(${zoomTarget})`,
+            opacity: 0.35,
+            filter: 'saturate(140%)',
+          },
+          { transform: 'translate(0%, 0%) scale(1)', opacity: 1, filter: 'saturate(100%)' },
+        ],
+        {
+          duration,
+          easing,
+          pseudoElement: '::view-transition-new(root)',
+        }
+      );
+      root.animate(
+        [
+          { transform: 'translate(0%, 0%) scale(1)', opacity: 1 },
+          {
+            transform: `translate(${-offsetX}%, ${-offsetY}%) scale(0.9)`,
+            opacity: 0.1,
+          },
+        ],
+        {
+          duration,
+          easing,
+          pseudoElement: '::view-transition-old(root)',
+        }
+      );
+    },
+  },
+];
+
+const THEME_TRANSITION_LOOKUP: Record<ThemeTransitionId, ThemeTransition> = THEME_TRANSITIONS.reduce(
+  (acc, transition) => {
+    acc[transition.id] = transition;
+    return acc;
+  },
+  {} as Record<ThemeTransitionId, ThemeTransition>
+);
 
 const shuffleArray = <T,>(items: readonly T[]) => {
   const cloned = [...items];
@@ -81,6 +258,16 @@ function App() {
 
     return initial;
   });
+  const [themeTransitionId, setThemeTransitionId] = useState<ThemeTransitionId>(() => {
+    if (typeof window === 'undefined') {
+      return 'fade';
+    }
+
+    const stored = window.localStorage.getItem('theme-transition');
+    return stored && ['fade', 'slide', 'flip', 'zoom'].includes(stored)
+      ? (stored as ThemeTransitionId)
+      : 'fade';
+  });
   const [isLoading, setIsLoading] = useState(true);
   const [progress, setProgress] = useState(0);
   const [elapsedMs, setElapsedMs] = useState<number | null>(null);
@@ -106,6 +293,14 @@ function App() {
   }, [isDarkMode]);
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem('theme-transition', themeTransitionId);
+  }, [themeTransitionId]);
+
+  useEffect(() => {
     if (typeof document === 'undefined') {
       return;
     }
@@ -113,17 +308,30 @@ function App() {
     document.documentElement.dataset.theme = isDarkMode ? 'dark' : 'light';
   }, [isDarkMode]);
 
+  const selectedTransition = useMemo(
+    () => THEME_TRANSITION_LOOKUP[themeTransitionId] ?? THEME_TRANSITIONS[0],
+    [themeTransitionId]
+  );
+
   const toggleTheme = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
+    (
+      event: React.MouseEvent<HTMLButtonElement>,
+      themeTransition: ThemeTransition,
+      nextTheme: 'light' | 'dark'
+    ) => {
       if (typeof document === 'undefined') {
         setIsDarkMode((prev) => !prev);
         return;
       }
 
-      const target = event.currentTarget;
-      const rect = target.getBoundingClientRect();
-      const x = rect.left + rect.width / 2;
-      const y = rect.top + rect.height / 2;
+      const pointer = {
+        x:
+          event.clientX ||
+          (typeof window !== 'undefined' ? window.innerWidth / 2 : 0),
+        y:
+          event.clientY ||
+          (typeof window !== 'undefined' ? window.innerHeight / 2 : 0),
+      };
 
       const updateTheme = () => {
         flushSync(() => {
@@ -142,24 +350,7 @@ function App() {
         transition.ready
           .then(() => {
             const root = document.documentElement;
-            const maxRadius = Math.hypot(
-              Math.max(x, window.innerWidth - x),
-              Math.max(y, window.innerHeight - y)
-            );
-
-            root.animate(
-              {
-                clipPath: [
-                  `circle(0px at ${x}px ${y}px)`,
-                  `circle(${maxRadius}px at ${x}px ${y}px)`,
-                ],
-              },
-              {
-                duration: 600,
-                easing: 'ease-in-out',
-                pseudoElement: '::view-transition-new(root)',
-              }
-            );
+            themeTransition.apply(root, { pointer, nextTheme });
           })
           .catch(() => {
             /* no-op: allow the theme change without the reveal animation */
@@ -425,7 +616,7 @@ function App() {
       <button
         type="button"
         className="theme-toggle"
-        onClick={toggleTheme}
+        onClick={(event) => toggleTheme(event, selectedTransition, isDarkMode ? 'light' : 'dark')}
         aria-label={isDarkMode ? 'تغییر به حالت روشن' : 'تغییر به حالت تیره'}
         title={isDarkMode ? 'تغییر به حالت روشن' : 'تغییر به حالت تیره'}
       >
@@ -433,6 +624,32 @@ function App() {
           {isDarkMode ? '☀️' : '🌙'}
         </span>
       </button>
+      <div className="theme-transition-picker" role="group" aria-label="انتخاب نوع انیمیشن تغییر تم">
+        <span className="theme-transition-picker__heading">انیمیشن تغییر تم</span>
+        <div className="theme-transition-picker__options">
+          {THEME_TRANSITIONS.map((transitionOption) => {
+            const isActive = transitionOption.id === themeTransitionId;
+            return (
+              <button
+                key={transitionOption.id}
+                type="button"
+                className={`theme-transition-picker__option${
+                  isActive ? ' theme-transition-picker__option--active' : ''
+                }`}
+                onClick={() => setThemeTransitionId(transitionOption.id)}
+                aria-pressed={isActive}
+                aria-label={transitionOption.description}
+                title={transitionOption.description}
+              >
+                <span aria-hidden="true" className="theme-transition-picker__icon">
+                  {transitionOption.icon}
+                </span>
+                <span className="theme-transition-picker__text">{transitionOption.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
       {/*<div className="elapsed-counter" aria-live="polite">*/}
       {/*  <span className="elapsed-counter__label">زمان سپری‌شده</span>*/}
       {/*  <span className="elapsed-counter__value">{formattedElapsed}</span>*/}


### PR DESCRIPTION
## Summary
- add four view-transition powered theme change effects and persist the user choice
- expose a picker in the UI for choosing between fade, slide, flip, and zoom animations
- refresh styling variables and responsive layout to support the new control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed91c2ea78832780ca51087b954b8e