### PR TITLE
Revise SEO metadata and sitemap tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "build": "react-scripts build",
     "build:ci": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "generate:sitemap": "node scripts/generate-sitemap.mjs"
   },
   "eslintConfig": {
     "extends": [

--- a/public/index.html
+++ b/public/index.html
@@ -4,20 +4,16 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#f8fafc" />
+    <meta name="color-scheme" content="light dark" />
     <meta
       name="description"
       content="وقتگیر تجربه‌ای تعاملی برای انتظار است که با انیمیشن‌های نرم، نقل‌قول‌های الهام‌بخش، لحظه‌های منتظر ماندن را به فرصتی برای تفکر تبدیل می‌کند."
-    />
-    <meta
-      name="keywords"
-      content="وقتگیر, وقت گیر, Vaghtgir, تجربه انتظار فارسی, Persian waiting experience, تایمر فارسی, Persian timer, صفحه در حال بارگذاری, Persian loading screen, تجربه کاربری فارسی, Persian UX, نقل قول انگیزشی, motivational quotes, بازاریابی انتظاری, waiting marketing"
     />
     <meta name="author" content="Mahdi Zarei (skyBlueDev)" />
     <meta name="creator" content="Mahdi Zarei (skyBlueDev)" />
     <meta name="publisher" content="Mahdi Zarei" />
     <meta name="application-name" content="وقتگیر" />
-    <meta name="robots" content="index, follow" />
     <meta name="category" content="بهره‌وری، ذهن‌آگاهی، بازاریابی" />
     <meta name="language" content="fa-IR" />
     <meta name="apple-mobile-web-app-title" content="وقتگیر" />
@@ -30,8 +26,10 @@
     />
     <meta property="og:site_name" content="وقتگیر" />
     <meta property="og:locale" content="fa_IR" />
-    <meta property="og:url" content="https://skybluedev.com/vaghtgir" />
-    <meta property="og:image" content="%PUBLIC_URL%/logo192.png" />
+    <meta property="og:url" content="" data-dynamic="true" />
+    <meta property="og:image" content="%PUBLIC_URL%/logo512.png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="لوگوی وقتگیر - تجربه زمان‌گیر فارسی" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="وقتگیر | ساختهٔ skyBlueDev" />
@@ -40,10 +38,57 @@
       content="وقتگیر با طراحی چشم‌نواز، جملات انگیزشی و حال‌وهوای لوکس، انتظار را به تجربه‌ای لذت‌بخش و اعتمادساز تبدیل می‌کند."
     />
     <meta name="twitter:creator" content="@skyBlueDev" />
-    <meta name="twitter:image" content="%PUBLIC_URL%/logo192.png" />
+    <meta name="twitter:image" content="%PUBLIC_URL%/logo512.png" />
     <meta name="twitter:image:alt" content="لوگوی وقتگیر - تجربه انتظار" />
-    <link rel="canonical" href="https://skybluedev.com/vaghtgir" />
+    <link rel="canonical" href="/" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <script id="structured-data" type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "وقتگیر",
+        "operatingSystem": "Web",
+        "applicationCategory": "LifestyleApplication",
+        "inLanguage": "fa-IR",
+        "description": "وقتگیر تجربه‌ای تعاملی و لوکس برای مدیریت لحظه‌های انتظار با نقل‌قول‌های الهام‌بخش و انیمیشن‌های نرم است.",
+        "url": "",
+        "creator": {
+          "@type": "Person",
+          "name": "Mahdi Zarei",
+          "alternateName": "skyBlueDev"
+        }
+      }
+    </script>
+    <script>
+      (function () {
+        try {
+          var canonical = document.querySelector('link[rel="canonical"]');
+          var path = window.location.pathname.replace(/index\.html$/, '');
+          var url = window.location.origin + path;
+          if (canonical) {
+            canonical.setAttribute('href', url);
+          }
+          var ogUrl = document.querySelector('meta[property="og:url"]');
+          if (ogUrl) {
+            ogUrl.setAttribute('content', url);
+          }
+          var jsonLd = document.getElementById('structured-data');
+          if (jsonLd && jsonLd.textContent) {
+            var data = JSON.parse(jsonLd.textContent);
+            data.url = url;
+            jsonLd.textContent = JSON.stringify(data);
+          }
+        } catch (error) {
+          if (
+            typeof process !== 'undefined' &&
+            process.env &&
+            process.env.NODE_ENV !== 'production'
+          ) {
+            console.warn('SEO metadata hydration skipped', error);
+          }
+        }
+      })();
+    </script>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,7 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "وقتگیر",
+  "name": "وقتگیر | تجربه‌ی لوکس انتظار",
+  "description": "وقتگیر تجربه‌ای تعاملی برای تبدیل انتظار به فرصتی آرامش‌بخش با انیمیشن‌های نرم و نقل‌قول‌های انگیزشی است.",
   "icons": [
     {
       "src": "favicon.ico",
@@ -18,8 +19,14 @@
       "sizes": "512x512"
     }
   ],
-  "start_url": ".",
+  "lang": "fa-IR",
+  "dir": "rtl",
+  "start_url": "/",
+  "scope": "/",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "display_override": ["standalone", "minimal-ui"],
+  "theme_color": "#f8fafc",
+  "background_color": "#f8fafc",
+  "categories": ["productivity", "lifestyle"],
+  "orientation": "portrait-primary"
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,6 @@
 User-agent: *
 Allow: /
 
+# Point crawlers to the generated sitemap once deployed
+Sitemap: /sitemap.xml
+

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  این فایل به صورت خودکار توسط اسکریپت scripts/generate-sitemap.mjs تولید می‌شود.
+  برای تولید نسخه نهایی، دستور زیر را با متغیر SITE_URL اجرا کنید:
+    SITE_URL="https://your-domain.example" npm run generate:sitemap
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,29 @@
+import { writeFile } from 'fs/promises';
+import { resolve } from 'path';
+
+const rawSiteUrl = (process.env.SITE_URL || '').trim();
+
+if (!rawSiteUrl) {
+  console.warn(
+    'Skipping sitemap generation because SITE_URL is not set. Provide SITE_URL to generate an absolute sitemap.'
+  );
+  process.exit(0);
+}
+
+const siteUrl = rawSiteUrl.replace(/\/+$/, '');
+const routes = ['/'];
+const lastMod = new Date().toISOString();
+
+const urlEntries = routes
+  .map((route, index) => {
+    const priority = index === 0 ? '1.0' : '0.5';
+    return `  <url>\n    <loc>${siteUrl}${route}</loc>\n    <lastmod>${lastMod}</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>${priority}</priority>\n  </url>`;
+  })
+  .join('\n');
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlEntries}\n</urlset>\n`;
+
+const outputPath = resolve('public', 'sitemap.xml');
+
+await writeFile(outputPath, xml, 'utf8');
+console.log(`sitemap.xml generated at ${outputPath} for ${siteUrl}`);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,4 +16,9 @@ root.render(
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+reportWebVitals((metric) => {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.log(metric);
+  }
+});


### PR DESCRIPTION
## Summary
- refresh the HTML head metadata by removing redundant tags, enlarging social images, and injecting structured data with a runtime canonical updater
- tailor the web app manifest to the Persian experience and expose a web vitals logger during development
- add sitemap scaffolding with a generator script and surface it in robots.txt

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69035dcb66688327bb22210df15b61ed